### PR TITLE
Better syntax checking when a package is being extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,15 @@ $ ./node_modules/.bin/sn-package-publish
 
 If the `allowExtends` option is set to `TRUE` then packages within the current repository can extend other (remote) packages _from the same [scope](#scope)_.
 
-To extend another package, you need to define the package you wish to extend as a dependency within the `package.json` file of the local package. This should take the form `"extendsPackage": "name@version"`. In the following example we would extend version `1.0.0` of the package `left-pad` from NPM:
+To extend another package, you need to define the package you wish to extend as a dependency within the `package.json` file of the local package. This should take the form `"extendsPackage": "name@version"`. In the following example we would extend version `1.0.0` of the package `global-button` from NPM:
 
 ```json
 {
-  "extendsPackage": "left-pad@1.0.0"
+  "extendsPackage": "global-button@1.0.0"
 }
 ```
+
+You _do not_ need to specify the scope as this is taken from the configuration, but you must specify a specific version using valid semver.
 
 Extending works by merging any files from the dependency package into the local package if they do not already exist. This process is designed to [run on your CI environment](#continuous-integration) during the publication stage. Take the following example file structures for a local package, and it's dependency:
 

--- a/lib/js/_utils/_extend-package.js
+++ b/lib/js/_utils/_extend-package.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const path = require('path');
+const semver = require('semver');
 
 const getExtendedFileList = require('./_get-extended-file-list');
 const getRemoteFile = require('./_get-remote-file');
@@ -65,6 +66,8 @@ function validate(config, packagePath) {
 		const packageJson = require(packageJsonPath);
 		const packageToExtend = `@${config.scope}/${packageJson.extendsPackage}`;
 		const isExtendedPackage = isExtended(packageJson);
+		const extendsPackageRegex = new RegExp('.+@.+', 'ig');
+		const extendsPackageVersion = packageJson.extendsPackage.substring(packageJson.extendsPackage.indexOf('@') + 1);
 
 		if (!isExtendedPackage) {
 			resolve();
@@ -75,6 +78,16 @@ function validate(config, packagePath) {
 
 		if (!config.allowExtends) {
 			reject(new Error('Package extension disabled for this repository'));
+			return;
+		}
+
+		if (!extendsPackageRegex.test(packageJson.extendsPackage)) {
+			reject(new Error('Invalid extension definition. Use the format `name-of-package@version`'));
+			return;
+		}
+
+		if (!semver.valid(extendsPackageVersion)) {
+			reject(new Error('Invalid extension version. Must be valid semver'));
 			return;
 		}
 


### PR DESCRIPTION
After an implementation issue in our test monorepo, this PR makes it clearer how you declare the package that is being extended, and adds better error messaging when the syntax is incorrect