### PR TITLE
Fix a bug in the way that package extension is handled

### DIFF
--- a/lib/js/_utils/_extend-package.js
+++ b/lib/js/_utils/_extend-package.js
@@ -67,7 +67,6 @@ function validate(config, packagePath) {
 		const packageToExtend = `@${config.scope}/${packageJson.extendsPackage}`;
 		const isExtendedPackage = isExtended(packageJson);
 		const extendsPackageRegex = new RegExp('.+@.+', 'ig');
-		const extendsPackageVersion = packageJson.extendsPackage.substring(packageJson.extendsPackage.indexOf('@') + 1);
 
 		if (!isExtendedPackage) {
 			resolve();
@@ -86,7 +85,11 @@ function validate(config, packagePath) {
 			return;
 		}
 
-		if (!semver.valid(extendsPackageVersion)) {
+		if (!semver.valid(
+			packageJson.extendsPackage.substring(
+				packageJson.extendsPackage.indexOf('@') + 1
+			)
+		)) {
 			reject(new Error('Invalid extension version. Must be valid semver'));
 			return;
 		}


### PR DESCRIPTION
BUG:
`packageJson.extendsPackage` doesn't exist for packages that are not being extended, so any reference to that is moved until after we drop out of the function at the `if (!isExtendedPackage)` check