### PR TITLE
Version 1.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 1.0.0 (2019-05-21)
+	* Removes dependency on npm-utils
+	* Stable version
+
 ## 0.2.0 (2018-10-18)
 	* Creates subdirectory structure
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@springernature/frontend-package-manager",
   "description": "handles the creation, validation, and publication of packages",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "license": "LGPL-3.0",
   "keywords": [
     "node",


### PR DESCRIPTION
Publish first stable version of package manager after the removal of `npm-utils` dependency