### PR TITLE
allows dotfiles anywhere in package

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,9 @@
 # History
 
-## 2.0.0 (2019-06-28)
+## 2.0.0 (2019-07-03)
 	* .dotfiles anywhere in a package now valid
 	
-## 1.0.1 (2019-07-3)
+## 1.0.1 (2019-07-03)
 	* Update package validation to allow .spec.js files
 
 ## 1.0.0 (2019-05-21)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 2.0.0 (2019-06-28)
+	* .dotfiles anywhere in a package now valid
+	
 ## 1.0.1 (2019-07-3)
 	* Update package validation to allow .spec.js files
 

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -11,10 +11,12 @@ const __fsMockFiles = () => {
 		'path/to/global-package': {
 			'required.md': 'file content',
 			'fail.md': 'file content',
+			'.adotfile': 'file content',
 			folder1: {
 				'file.scss': 'file content',
 				'file.css': 'file content',
-				'file.js': 'file content'
+				'file.js': 'file content',
+				'.anotherdotfile': 'nested dotfile content'
 			},
 			folder2: {
 				'file.js': 'file content',

--- a/__mocks__/glob.js
+++ b/__mocks__/glob.js
@@ -35,7 +35,7 @@ const results = {
 		'path/to/global-package/required.md',
 		'path/to/global-package/.adotfile',
 		'path/to/global-package/folder1',
-		'path/to/global-package/folder1/.anotherdotfile',
+		'path/to/global-package/folder1/.anotherdotfile'
 	],
 	failIsRequired: [
 		'path/to/global-package/folder1',

--- a/__mocks__/glob.js
+++ b/__mocks__/glob.js
@@ -31,6 +31,12 @@ const results = {
 		'path/to/global-package/folder3/file.scss',
 		'path/to/global-package/folder3/file.js'
 	],
+	passDotfiles: [
+		'path/to/global-package/required.md',
+		'path/to/global-package/.adotfile',
+		'path/to/global-package/folder1',
+		'path/to/global-package/folder1/.anotherdotfile',
+	],
 	failIsRequired: [
 		'path/to/global-package/folder1',
 		'path/to/global-package/folder1/file.scss',

--- a/__tests__/unit/_validate/check-package-structure.js
+++ b/__tests__/unit/_validate/check-package-structure.js
@@ -59,6 +59,13 @@ describe('Check validation', () => {
 		).rejects.toBeInstanceOf(Error);
 	});
 
+	test('Does not reject when dotfiles included', () => {
+		expect.assertions(1);
+		return expect(
+			checkValidation(validationConfig, 'path/to/global-package', 'passDotfiles')
+		).resolves.toEqual();
+	});
+
 	test('Rejects when invalid folder present', () => {
 		expect.assertions(1);
 		return expect(

--- a/lib/js/_validate/_check-package-structure.js
+++ b/lib/js/_validate/_check-package-structure.js
@@ -112,10 +112,13 @@ function isFileType(item) {
 
 // Filter glob results
 // Remove directory string
-// Remove paths matching .gitignore
+// Remove paths matching .gitignore'd files
+// Remove dotfiles
 function getFilteredResults(directory, files) {
 	const globs = gitParse(gitignorePath);
 	const pattern = (globs.length > 1) ? `{${globs.join(',')}}` : globs[0];
+	files = files.map(pathAndFile => pathAndFile.replace(`${directory}/`, ''));
+
 	const exclude = files.filter(
 		minimatch.filter(pattern,
 			{
@@ -125,9 +128,13 @@ function getFilteredResults(directory, files) {
 		)
 	);
 
-	return files
-		.filter(el => !exclude.includes(el))
-		.map(s => s.replace(`${directory}/`, ''));
+	// https://github.com/regexhq/dotfile-regex/blob/master/index.js
+	const dotfileRegex = /(?:^|[\\\/])(\.(?!\.)[^\\\/]+)$/;
+	const result = files
+		.filter(el => !dotfileRegex.test(el))
+		.filter(el => !exclude.includes(el));
+
+	return result;
 }
 
 // Validation
@@ -199,4 +206,3 @@ function init(validationConfig, packagePath, options) {
 }
 
 module.exports = init;
-

--- a/lib/js/_validate/_check-package-structure.js
+++ b/lib/js/_validate/_check-package-structure.js
@@ -129,7 +129,7 @@ function getFilteredResults(directory, files) {
 	);
 
 	// https://github.com/regexhq/dotfile-regex/blob/master/index.js
-	const dotfileRegex = /(?:^|[\\\/])(\.(?!\.)[^\\\/]+)$/;
+	const dotfileRegex = /(?:^|[\\\/])(\.(?!\.)[^\\\/]+)$/; // eslint-disable-line no-useless-escape
 	const result = files
 		.filter(el => !dotfileRegex.test(el))
 		.filter(el => !exclude.includes(el));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@springernature/frontend-package-manager",
   "description": "handles the creation, validation, and publication of packages",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "license": "LGPL-3.0",
   "keywords": [
     "node",


### PR DESCRIPTION
We have made a decision to allow packages to specify their own Babel configs via `.babelrc` files, but this breaks package validation.

As a result I think/assume it is OK to allow packages to contain dotfiles anywhere in the package. That is quite an assumption!

Super happy to discuss this further in which case I will update this PR, but thought I would like to check the overall approach in code first.