### PR TITLE
Fix extension string splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ typings/
 
 # next.js build output
 .next
+
+# IDE
+/.idea/
+*.iml

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -18,6 +18,7 @@ const __fsMockFiles = () => {
 			},
 			folder2: {
 				'file.js': 'file content',
+				'file.spec.js': 'file content',
 				'file.json': 'file content',
 				subfolder: {
 					'file.js': 'file content'

--- a/__mocks__/glob.js
+++ b/__mocks__/glob.js
@@ -12,6 +12,7 @@ const results = {
 		'path/to/global-package/folder1/file.css',
 		'path/to/global-package/folder2',
 		'path/to/global-package/folder2/file.js',
+		'path/to/global-package/folder2/file.spec.js',
 		'path/to/global-package/folder2/file.json',
 		'path/to/global-package/folder2/subfolder',
 		'path/to/global-package/folder2/subfolder/file.js'

--- a/lib/js/_validate/_check-package-structure.js
+++ b/lib/js/_validate/_check-package-structure.js
@@ -75,7 +75,8 @@ function isFileType(item) {
 	const splitGlob = item.split('/');
 	if (splitGlob.length > 1) {
 		const topLevelFolder = splitGlob[0];
-		const extension = splitGlob[splitGlob.length - 1].split('.')[1];
+		const fileNameSplit = splitGlob[splitGlob.length - 1].split('.');
+		const extension = fileNameSplit[fileNameSplit.length - 1];
 
 		if (!validFolders) {
 			showOutput.log([{


### PR DESCRIPTION
Splits the filename string at the last `.` instead of the first.
This allows for the use of files names like `myfile.spec.js`