### PR TITLE
Unpkg Bug Fix

### DIFF
--- a/__tests__/unit/_utils/get-remote-file.js
+++ b/__tests__/unit/_utils/get-remote-file.js
@@ -16,7 +16,7 @@ describe('Getting contents of a remote file from a URL', () => {
 
 		expect.assertions(1);
 		return expect(
-			getRemoteFile('https://www.example.com/success', 'package')
+			getRemoteFile('https://www.example.com/success')
 		).resolves.toEqual('domain matched');
 	});
 
@@ -27,7 +27,7 @@ describe('Getting contents of a remote file from a URL', () => {
 
 		expect.assertions(1);
 		return expect(
-			getRemoteFile('https://www.example.com/notfound', 'package')
+			getRemoteFile('https://www.example.com/notfound')
 		).rejects.toBeInstanceOf(Error);
 	});
 
@@ -38,7 +38,7 @@ describe('Getting contents of a remote file from a URL', () => {
 
 		expect.assertions(1);
 		return expect(
-			getRemoteFile('https://www.example.com/failure', 'package')
+			getRemoteFile('https://www.example.com/failure')
 		).rejects.toBeInstanceOf(Error);
 	});
 

--- a/lib/js/_utils/__mocks__/_get-remote-file.js
+++ b/lib/js/_utils/__mocks__/_get-remote-file.js
@@ -6,9 +6,9 @@
 
 const results = '{"path":"/","type":"directory","files":[{"path":"/topLevelFileA.ext","type":"file"},{"path":"/topLevelFileB.ext","type":"file"},{"path":"/topLevelDirA","type":"directory","files":[{"path":"/topLevelDirA/secondLevelDirA","type":"directory","files":[{"path":"/topLevelDirA/secondLevelDirA/fileA.ext","type":"file"},{"path":"/topLevelDirA/secondLevelDirA/fileB.ext","type":"file"}]},{"path":"/topLevelDirA/fileA.ext","type":"file"},{"path":"/topLevelDirA/secondLevelDirB","type":"directory","files":[{"path":"/topLevelDirA/secondLevelDirB/fileA.ext","type":"file"}]}]},{"path":"/topLevelDirB","type":"directory","files":[{"path":"/topLevelDirB/fileA.ext","type":"file"}]},{"path":"/topLevelFileC.ext","type":"file"}]}';
 
-function getRemoteFile(url, name) {
+function getRemoteFile(url) {
 	return new Promise((resolve, reject) => {
-		if (name === 'success') {
+		if (url.includes('success')) {
 			resolve(results);
 		}
 		reject(reject(new Error('error')));

--- a/lib/js/_utils/_extend-package.js
+++ b/lib/js/_utils/_extend-package.js
@@ -94,7 +94,7 @@ function validate(config, packagePath) {
 			return;
 		}
 
-		getRemoteFile(`https://unpkg.com/${packageToExtend}/`, packageToExtend)
+		getRemoteFile(`https://unpkg.com/${packageToExtend}/`)
 			.then(() => {
 				showOutput.log([{
 					type: 'success',

--- a/lib/js/_utils/_extend-package.js
+++ b/lib/js/_utils/_extend-package.js
@@ -94,7 +94,7 @@ function validate(config, packagePath) {
 			return;
 		}
 
-		getRemoteFile(`https://unpkg.com/${packageToExtend}/`)
+		getRemoteFile(`https://unpkg.com/${packageToExtend}/?meta`)
 			.then(() => {
 				showOutput.log([{
 					type: 'success',

--- a/lib/js/_utils/_get-extended-file-list.js
+++ b/lib/js/_utils/_get-extended-file-list.js
@@ -22,7 +22,7 @@ function getFileList(json, filePaths = []) {
 
 function getExtendedFileList(name) {
 	return new Promise((resolve, reject) => {
-		getRemoteFile(`https://unpkg.com/${name}/?meta`, name)
+		getRemoteFile(`https://unpkg.com/${name}/?meta`)
 			.then(html => {
 				const fileList = getFileList(JSON.parse(html).files);
 				resolve(fileList);

--- a/lib/js/_utils/_get-remote-file.js
+++ b/lib/js/_utils/_get-remote-file.js
@@ -8,13 +8,13 @@
 
 const https = require('https');
 
-function getRemoteFile(url, packageName) {
+function getRemoteFile(url) {
 	return new Promise((resolve, reject) => {
 		const request = https.get(url, response => {
 			const body = [];
 
 			if (response.statusCode < 200 || response.statusCode > 399) {
-				reject(new Error(`Failed to load \`${packageName}\`, status code: \`${response.statusCode}\``));
+				reject(new Error(`${response.statusCode}: ${url}`));
 			}
 
 			response.on('data', chunk => body.push(chunk));

--- a/lib/js/_utils/_get-remote-file.js
+++ b/lib/js/_utils/_get-remote-file.js
@@ -13,7 +13,7 @@ function getRemoteFile(url, packageName) {
 		const request = https.get(url, response => {
 			const body = [];
 
-			if (response.statusCode < 200 || response.statusCode > 299) {
+			if (response.statusCode < 200 || response.statusCode > 399) {
 				reject(new Error(`Failed to load \`${packageName}\`, status code: \`${response.statusCode}\``));
 			}
 

--- a/lib/js/_utils/_merge-extended-package.js
+++ b/lib/js/_utils/_merge-extended-package.js
@@ -23,7 +23,7 @@ function mergeExtendedPackage(extendedFileList, packagePath, name) {
 			try {
 				fs.accessSync(filePath, fs.constants.F_OK);
 			} catch (err) {
-				const promise = getRemoteFile(`https://unpkg.com/${name}${file}`, name)
+				const promise = getRemoteFile(`https://unpkg.com/${name}${file}`)
 					.then(data => {
 						fs.ensureDirSync(path.dirname(filePath));
 						fs.writeFileSync(filePath, data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1498,8 +1498,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "optional": true
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -2578,8 +2577,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2600,14 +2598,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2622,20 +2618,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2752,8 +2745,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2765,7 +2757,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2780,7 +2771,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2788,14 +2778,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2814,7 +2802,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2895,8 +2882,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2908,7 +2894,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2994,8 +2979,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3031,7 +3015,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3051,7 +3034,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3095,14 +3077,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3158,7 +3138,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }


### PR DESCRIPTION
`unpkg.com` allows you to append a / at the end of a URL to view a listing of all the files in a package. The behavior for this has changed to redirect those requests to `/browse`. This PR makes our use of `unpkg.com` more robust by:

* allowing http status codes in the range `3.x.x`
* changing our base level request to use the `?meta` flag, which avoids the redirect
* improving the `_get-remote-file` error messaging to display the full URL of the file that was requested