### PR TITLE
Switch to use jsDelivr as CDN instead of unpkg

### DIFF
--- a/lib/js/_utils/__mocks__/_get-remote-file.js
+++ b/lib/js/_utils/__mocks__/_get-remote-file.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-const results = '{"path":"/","type":"directory","files":[{"path":"/topLevelFileA.ext","type":"file"},{"path":"/topLevelFileB.ext","type":"file"},{"path":"/topLevelDirA","type":"directory","files":[{"path":"/topLevelDirA/secondLevelDirA","type":"directory","files":[{"path":"/topLevelDirA/secondLevelDirA/fileA.ext","type":"file"},{"path":"/topLevelDirA/secondLevelDirA/fileB.ext","type":"file"}]},{"path":"/topLevelDirA/fileA.ext","type":"file"},{"path":"/topLevelDirA/secondLevelDirB","type":"directory","files":[{"path":"/topLevelDirA/secondLevelDirB/fileA.ext","type":"file"}]}]},{"path":"/topLevelDirB","type":"directory","files":[{"path":"/topLevelDirB/fileA.ext","type":"file"}]},{"path":"/topLevelFileC.ext","type":"file"}]}';
+const results = '{"default":null,"files":[{"name":"topLevelFileA.ext","type":"file"},{"name":"topLevelFileB.ext","type":"file"},{"name":"topLevelDirA","type":"directory","files":[{"name":"secondLevelDirA","type":"directory","files":[{"name":"fileA.ext","type":"file"},{"name":"fileB.ext","type":"file"}]},{"name":"fileA.ext","type":"file"},{"name":"secondLevelDirB","type":"directory","files":[{"name":"fileA.ext","type":"file"}]}]},{"name":"topLevelDirB","type":"directory","files":[{"name":"fileA.ext","type":"file"}]},{"name":"topLevelFileC.ext","type":"file"}]}';
 
 function getRemoteFile(url) {
 	return new Promise((resolve, reject) => {

--- a/lib/js/_utils/_extend-package.js
+++ b/lib/js/_utils/_extend-package.js
@@ -94,7 +94,7 @@ function validate(config, packagePath) {
 			return;
 		}
 
-		getRemoteFile(`https://unpkg.com/${packageToExtend}/?meta`)
+		getRemoteFile(`https://data.jsdelivr.com/v1/package/npm/${packageToExtend}`)
 			.then(() => {
 				showOutput.log([{
 					type: 'success',

--- a/lib/js/_utils/_get-extended-file-list.js
+++ b/lib/js/_utils/_get-extended-file-list.js
@@ -8,13 +8,13 @@ const getRemoteFile = require('./_get-remote-file');
 
 // Loop through package contents
 // Return list of all files found
-function getFileList(json, filePaths = []) {
+function getFileList(json, filePaths = [], buildPath = '/') {
 	json.forEach(file => {
 		if (file.type === 'file') {
-			filePaths.push(file.path);
+			filePaths.push(`${buildPath}${file.name}`);
 		}
 		if (file.type === 'directory') {
-			getFileList(file.files, filePaths);
+			getFileList(file.files, filePaths, `${buildPath}${file.name}/`);
 		}
 	});
 	return filePaths;
@@ -22,7 +22,7 @@ function getFileList(json, filePaths = []) {
 
 function getExtendedFileList(name) {
 	return new Promise((resolve, reject) => {
-		getRemoteFile(`https://unpkg.com/${name}/?meta`)
+		getRemoteFile(`https://data.jsdelivr.com/v1/package/npm/${name}`)
 			.then(html => {
 				const fileList = getFileList(JSON.parse(html).files);
 				resolve(fileList);

--- a/lib/js/_utils/_get-remote-file.js
+++ b/lib/js/_utils/_get-remote-file.js
@@ -1,7 +1,6 @@
 /**
  * _get-remote-file.js
  * Get the contents of a remote file
- * Used to get package contents from https://unpkg.com/
  * HTTPS only
  */
 'use strict';

--- a/lib/js/_utils/_merge-extended-package.js
+++ b/lib/js/_utils/_merge-extended-package.js
@@ -23,7 +23,7 @@ function mergeExtendedPackage(extendedFileList, packagePath, name) {
 			try {
 				fs.accessSync(filePath, fs.constants.F_OK);
 			} catch (err) {
-				const promise = getRemoteFile(`https://unpkg.com/${name}${file}`)
+				const promise = getRemoteFile(`https://cdn.jsdelivr.net/npm/${name}${file}`)
 					.then(data => {
 						fs.ensureDirSync(path.dirname(filePath));
 						fs.writeFileSync(filePath, data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/frontend-package-manager",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1498,7 +1498,8 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "optional": true
     },
     "contains-path": {
       "version": "0.1.0",
@@ -2577,7 +2578,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2598,12 +2600,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2618,17 +2622,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2745,7 +2752,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2757,6 +2765,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2771,6 +2780,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2778,12 +2788,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2802,6 +2814,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2882,7 +2895,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2894,6 +2908,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2979,7 +2994,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3015,6 +3031,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3034,6 +3051,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3077,12 +3095,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3138,6 +3158,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }


### PR DESCRIPTION
We were having reliability issues with `unpkg` so have switched to `jsDelivr`. Because of how the json tree is represented this also involves a small change in the function that assembles the file list.

I am in the process of moving the package extension code to it's own package as it is needed elsewhere, and at the same time will make this more robust by falling back to NPM installing the package to get the file contents instead of grabbing them from the CDN.