### PR TITLE
Convert Promises to Async/Await

### DIFF
--- a/__mocks__/globby.js
+++ b/__mocks__/globby.js
@@ -9,19 +9,17 @@ const results = require('./glob-results');
 const resultsToolkits = results.toolkitFiles();
 const resultsPackage = results.packageFiles();
 
-const globby = (path, _options) => {
-	return new Promise((resolve, reject) => {
-		// Check toolkit results
-		if (path.includes('toolkits')) {
-			if (path.includes('toolkits-no-globby')) {
-				reject(new Error('globby error'));
-			}
-			resolve(resultsToolkits[path]);
+async function globby(path, _options) {
+	// Check toolkit results
+	if (path.includes('toolkits')) {
+		if (path.includes('toolkits-no-globby')) {
+			throw new Error('globby error');
 		}
+		return resultsToolkits[path];
+	}
 
-		// Check package results
-		resolve(resultsPackage[path]);
-	});
-};
+	// Check package results
+	return resultsPackage[path];
+}
 
 module.exports = globby;

--- a/__mocks__/npm-utils.js
+++ b/__mocks__/npm-utils.js
@@ -4,13 +4,10 @@
  */
 'use strict';
 
-function setAuthToken(path) {
-	return new Promise((resolve, reject) => {
-		if (path === 'path/to/fail') {
-			reject();
-		}
-		resolve();
-	});
+async function setAuthToken(path) {
+	if (path === 'path/to/fail') {
+		throw new Error('setAuthToken fail');
+	}
 }
 
 const publish = () => null;

--- a/__tests__/unit/_publish/set-auth-token.js
+++ b/__tests__/unit/_publish/set-auth-token.js
@@ -29,10 +29,10 @@ describe('Set the auth token inside the correct .npmrc file', () => {
 		mockfs(MOCK_PACKAGES);
 	});
 	
-	test('Save new contents', () => {
+	test('Save new contents', async () => {
 		mockos({'homedir': 'home/user'});
 		expect.assertions(1);
-		return expect(
+		await expect(
 			setAuthToken('path/to/auth-package', null)
 		).resolves.toEqual({
 			description: 'npmrc file saved',
@@ -40,10 +40,10 @@ describe('Set the auth token inside the correct .npmrc file', () => {
 		});
 	});
 
-	test('Save new contents using custom registry', () => {
+	test('Save new contents using custom registry', async () => {
 		mockos({'homedir': 'home/user'});
 		expect.assertions(1);
-		return expect(
+		await expect(
 			setAuthToken('path/to/auth-package-custom', null)
 		).resolves.toEqual({
 			description: 'npmrc file saved',
@@ -51,10 +51,10 @@ describe('Set the auth token inside the correct .npmrc file', () => {
 		});
 	});
 
-	test('Contents already exists', () => {
+	test('Contents already exists', async () => {
 		mockos({'homedir': 'home/user-b'});
 		expect.assertions(1);
-		return expect(
+		await expect(
 			setAuthToken('path/to/auth-package', null)
 		).resolves.toEqual({
 			description: 'npmrc file already has correct contents',
@@ -62,10 +62,10 @@ describe('Set the auth token inside the correct .npmrc file', () => {
 		});
 	});
 
-	test('Auth token already set', () => {
+	test('Auth token already set', async () => {
 		mockos({'homedir': 'home/user-c'});
 		expect.assertions(1);
-		return expect(
+		await expect(
 			setAuthToken('path/to/auth-package', null)
 		).rejects.toBeInstanceOf(Error);
 	});

--- a/__tests__/unit/_utils/check-exists.js
+++ b/__tests__/unit/_utils/check-exists.js
@@ -14,44 +14,44 @@ describe('Check if files/folders exist on the filesystem', () => {
 		mockfs(MOCK_PACKAGES);
 	});
 
-	test('Resolve if file exists', () => {
+	test('Resolve if file exists', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			exists.fileExists('path/to/some.png')
 		).resolves.toEqual('path/to/some.png');
 	});
 
-	test('Resolve if folder exists', () => {
+	test('Resolve if folder exists', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			exists.directoryExists('some/other/path')
 		).resolves.toEqual('some/other/path');
 	});
 
-	test('Reject if file does NOT exist', () => {
+	test('Reject if file does NOT exist', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			exists.fileExists('path/to/other.png')
 		).rejects.toBeInstanceOf(Error);
 	});
 
-	test('Reject if folder does NOT exist', () => {
+	test('Reject if folder does NOT exist', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			exists.directoryExists('some/other/invalid/path')
 		).rejects.toBeInstanceOf(Error);
 	});
 
-	test('Reject if file when checking directory', () => {
+	test('Reject if file when checking directory', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			exists.directoryExists('path/to/other.png')
 		).rejects.toBeInstanceOf(Error);
 	});
 
-	test('Reject if directory when checking file', () => {
+	test('Reject if directory when checking file', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			exists.fileExists('some/other/path')
 		).rejects.toBeInstanceOf(Error);
 	});

--- a/__tests__/unit/_validate/check-changed-files.js
+++ b/__tests__/unit/_validate/check-changed-files.js
@@ -12,9 +12,9 @@ jest.mock('path/to/global-package/package.json', () => ({
 const checkFiles = require('../../../lib/js/_validate/_check-changed-files');
 
 describe('Check correct files appear in CI changed files list', () => {
-	test('Reject if changelog not updated', () => {
+	test('Reject if changelog not updated', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkFiles(
 				'path/to/global-package',
 				'global-package/package.json',
@@ -23,9 +23,9 @@ describe('Check correct files appear in CI changed files list', () => {
 		).rejects.toBeInstanceOf(Error);
 	});
 
-	test('Reject if package.json not updated', () => {
+	test('Reject if package.json not updated', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkFiles(
 				'path/to/global-package',
 				'global-package/HISTORY.md',
@@ -34,9 +34,9 @@ describe('Check correct files appear in CI changed files list', () => {
 		).rejects.toBeInstanceOf(Error);
 	});
 
-	test('Resolve if both changelog & package.json are updated', () => {
+	test('Resolve if both changelog & package.json are updated', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkFiles(
 				'path/to/global-package',
 				'global-package/HISTORY.md\nglobal-package/package.json',

--- a/__tests__/unit/_validate/check-license.js
+++ b/__tests__/unit/_validate/check-license.js
@@ -12,16 +12,16 @@ jest.mock('path/to/global-package/package.json', () => ({
 const checkLicense = require('../../../lib/js/_validate/_check-license');
 
 describe('Check for correct license', () => {
-	test('License matches global license', () => {
+	test('License matches global license', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkLicense('path/to/global-package', 'license-name')
 		).resolves.toEqual();
 	});
 
-	test('Reject if license does not match global license', () => {
+	test('Reject if license does not match global license', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkLicense('path/to/global-package', 'wrong-license-name')
 		).rejects.toBeInstanceOf(Error);
 	});

--- a/__tests__/unit/_validate/check-naming.js
+++ b/__tests__/unit/_validate/check-naming.js
@@ -12,9 +12,9 @@ jest.mock('path/to/global-package/package.json', () => ({
 const checkNaming = require('../../../lib/js/_validate/_check-naming');
 
 describe('Check naming conventions', () => {
-	test('Package and folder names are valid (with prefix)', () => {
+	test('Package and folder names are valid (with prefix)', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkNaming(
 				{
 					scope: 'springernature',
@@ -26,9 +26,9 @@ describe('Check naming conventions', () => {
 		).resolves.toEqual();
 	});
 
-	test('Reject if Package name is not valid (with prefix)', () => {
+	test('Reject if Package name is not valid (with prefix)', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkNaming(
 				{
 					scope: 'fail',
@@ -40,9 +40,9 @@ describe('Check naming conventions', () => {
 		).rejects.toBeInstanceOf(Error);
 	});
 
-	test('Reject if Folder name is not valid (with prefix)', () => {
+	test('Reject if Folder name is not valid (with prefix)', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkNaming(
 				{
 					scope: 'springernature',
@@ -54,9 +54,9 @@ describe('Check naming conventions', () => {
 		).rejects.toBeInstanceOf(Error);
 	});
 
-	test('Package and folder names are valid (without prefix)', () => {
+	test('Package and folder names are valid (without prefix)', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkNaming(
 				{
 					scope: 'springernature',
@@ -68,9 +68,9 @@ describe('Check naming conventions', () => {
 		).resolves.toEqual();
 	});
 
-	test('Reject if Package name is not valid (without prefix)', () => {
+	test('Reject if Package name is not valid (without prefix)', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkNaming(
 				{
 					scope: 'fail',

--- a/__tests__/unit/_validate/check-publish-file.js
+++ b/__tests__/unit/_validate/check-publish-file.js
@@ -9,9 +9,9 @@ jest.mock('@springernature/util-cli-reporter');
 const checkPublishFile = require('../../../lib/js/_validate/_check-publish-file');
 
 describe('Check for updating of file when publishing', () => {
-	test('Resolve if file has been updated', () => {
+	test('Resolve if file has been updated', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkPublishFile(
 				'filename.ext\npath/to/global-package/file.ext\nothername.ext',
 				'global-package/file.ext'
@@ -19,9 +19,9 @@ describe('Check for updating of file when publishing', () => {
 		).resolves.toEqual();
 	});
 
-	test('Reject if file has not been updated', () => {
+	test('Reject if file has not been updated', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkPublishFile(
 				'filename.ext\npath/to/other-package/file.ext\nothername.ext',
 				'global-package/file.ext'
@@ -29,9 +29,9 @@ describe('Check for updating of file when publishing', () => {
 		).rejects.toBeInstanceOf(Error);
 	});
 
-	test('Reject if wrong file has been updated', () => {
+	test('Reject if wrong file has been updated', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkPublishFile(
 				'filename.ext\npath/to/global-package/file.ext\nothername.ext',
 				'global-package/other.ext'
@@ -39,9 +39,9 @@ describe('Check for updating of file when publishing', () => {
 		).rejects.toBeInstanceOf(Error);
 	});
 
-	test('Reject if error in retrieving changed files', () => {
+	test('Reject if error in retrieving changed files', async () => {
 		expect.assertions(1);
-		return expect(
+		await expect(
 			checkPublishFile(
 				undefined,
 				'global-package/file.ext'

--- a/bin/publish.js
+++ b/bin/publish.js
@@ -9,7 +9,8 @@ const generateConfig = require('../lib/js/_utils/_generate-config');
 const getToolkitLocations = require('../lib/js/_utils/_get-toolkit-locations');
 const publishPackages = require('../lib/js/_publish');
 
-const packageJsonPath = path.resolve(process.cwd(), 'package.json');
+const rootPath = process.cwd();
+const packageJsonPath = path.resolve(rootPath, 'package.json');
 
 reporter.title('package publication');
 reporter.info('searching for toolkits');
@@ -18,7 +19,7 @@ reporter.info('searching for toolkits');
 	try {
 		const toolkitInfoObject = await getToolkitLocations({}, 'toolkits');
 		const configs = await generateConfig(packageJsonPath, toolkitInfoObject);
-		publishPackages(configs);
+		publishPackages(configs, rootPath);
 	} catch (err) {
 		error(err);
 	}

--- a/lib/js/_publish.js
+++ b/lib/js/_publish.js
@@ -20,13 +20,14 @@ const publishToNpm = require('./_publish/_publish-to-npm');
  * @function publishPackage
  * @param {String} scope the NPM scope for publishing
  * @param {Object} pathToPackage package path on filesystem
+ * @param {String} rootPath repository root directory
  * @return {Promise}
  */
-async function publishPackage(scope, pathToPackage) {
+async function publishPackage(scope, pathToPackage, rootPath) {
 	if (await checkCurrentVersion(pathToPackage, true)) {
 		try {
 			await extendPackage(scope, pathToPackage);
-			await publishToNpm(pathToPackage);
+			await publishToNpm(pathToPackage, rootPath);
 		} catch (err) {
 			throw err;
 		}
@@ -36,8 +37,9 @@ async function publishPackage(scope, pathToPackage) {
 /**
  * Publish updated packages
  * @param {Object} allConfigs details of all toolkits to validate
+ * @param {String} rootPath repository root directory
  */
-module.exports = allConfigs => {
+module.exports = (allConfigs, rootPath) => {
 	let totalPaths = 0;
 
 	if (!process.env.NPM_TOKEN) {
@@ -59,7 +61,7 @@ module.exports = allConfigs => {
 
 				// Iterate over paths and validate
 				for (const path of packagePaths) {
-					await publishPackage(config.scope, path);
+					await publishPackage(config.scope, path, rootPath);
 				}
 			}
 

--- a/lib/js/_publish/_publish-package.js
+++ b/lib/js/_publish/_publish-package.js
@@ -32,17 +32,13 @@ function publishToNpm(cmd) {
 	});
 }
 
-function publish() {
-	return new Promise((resolve, reject) => {
-		publishToNpm(command)
-			.then(() => {
-				reporter.success('publish to npm?', 'true');
-				resolve();
-			})
-			.catch(err => {
-				reject(err);
-			});
-	});
+async function publish() {
+	try {
+		await publishToNpm(command);
+		reporter.success('publish to npm?', 'true');
+	} catch (err) {
+		throw err;
+	}
 }
 
 module.exports = publish;

--- a/lib/js/_publish/_publish-to-npm.js
+++ b/lib/js/_publish/_publish-to-npm.js
@@ -9,25 +9,24 @@ const reporter = require('@springernature/util-cli-reporter');
 const setAuthToken = require('./_set-auth-token');
 const publish = require('./_publish-package');
 
-function publishToNpm(path) {
-	return new Promise((resolve, reject) => {
-		try {
-			process.chdir(path);
-			reporter.info('switching to package dir', process.cwd());
-			setAuthToken(path, null)
-				.then(msg => {
-					reporter.info(msg.description, msg.text);
-					publish()
-						.then(resolve)
-						.catch(err => reject(err));
-				})
-				.catch(err => {
-					reject(err);
-				});
-		} catch (err) {
-			reject(err);
-		}
-	});
+async function publishToNpm(path, rootPath) {
+	try {
+		// Switch to the package directory
+		process.chdir(path);
+		reporter.info('switching to package dir', process.cwd());
+
+		// Set the auth token
+		const msg = await setAuthToken(path, null);
+		reporter.info(msg.description, msg.text);
+
+		// Publish package
+		await publish();
+
+		// Switch back to the repository root
+		process.chdir(rootPath);
+	} catch (err) {
+		throw err;
+	}
 }
 
 module.exports = publishToNpm;

--- a/lib/js/_publish/_set-auth-token.js
+++ b/lib/js/_publish/_set-auth-token.js
@@ -13,41 +13,37 @@ const formUrlToken = require('./_form-auth-token');
 const registryUrl = 'https://registry.npmjs.org/';
 
 // Make sure correct .npmrc file is set
-function updateNpmrc(data, fullRegistryUrl) {
-	return new Promise((resolve, reject) => {
-		const home = require('os').homedir();
-		const npmrcFile = join(home, '.npmrc');
-		let contents = '';
+async function updateNpmrc(data, fullRegistryUrl) {
+	const home = require('os').homedir();
+	const npmrcFile = join(home, '.npmrc');
+	let contents = '';
 
-		// If .npmrc already exists, get the contents
-		if (fs.existsSync(npmrcFile)) {
-			contents = fs.readFileSync(npmrcFile, 'utf-8');
-			contents = contents.trim() + '\n';
-		}
+	// If .npmrc already exists, get the contents
+	if (fs.existsSync(npmrcFile)) {
+		contents = fs.readFileSync(npmrcFile, 'utf-8');
+		contents = contents.trim() + '\n';
+	}
 
-		// Exit early if contents already correct
-		if (contents.indexOf(data.token) !== -1) {
-			resolve({
-				description: 'npmrc file already has correct contents',
-				text: 'skipping file generation'
-			});
-			return;
-		}
+	// Exit early if contents already correct
+	if (contents.indexOf(data.token) !== -1) {
+		return {
+			description: 'npmrc file already has correct contents',
+			text: 'skipping file generation'
+		};
+	}
 
-		// Reject if an auth token has already been set for this URL
-		if (contents.indexOf(data.test) !== -1) {
-			reject(new Error(`Authentication token already set for ${fullRegistryUrl}`));
-			return;
-		}
+	// Reject if an auth token has already been set for this URL
+	if (contents.indexOf(data.test) !== -1) {
+		throw new Error(`Authentication token already set for ${fullRegistryUrl}`);
+	}
 
-		// write the .npmrc file
-		fs.writeFileSync(npmrcFile, contents += data.token + '\n', 'utf-8');
+	// write the .npmrc file
+	fs.writeFileSync(npmrcFile, contents += data.token + '\n', 'utf-8');
 
-		resolve({
-			description: 'npmrc file saved',
-			text: npmrcFile
-		});
-	});
+	return {
+		description: 'npmrc file saved',
+		text: npmrcFile
+	};
 }
 
 // Set the correct auth token in .npmrc

--- a/lib/js/_publish/_set-auth-token.js
+++ b/lib/js/_publish/_set-auth-token.js
@@ -51,8 +51,8 @@ function updateNpmrc(data, fullRegistryUrl) {
 }
 
 // Set the correct auth token in .npmrc
-function setAuthToken(path, tokenEnvName) {
-	return new Promise((resolve, reject) => {
+async function setAuthToken(path, tokenEnvName) {
+	try {
 		const pkg = require(`${path}/package.json`);
 		let registry;
 
@@ -66,14 +66,11 @@ function setAuthToken(path, tokenEnvName) {
 		reporter.info('setting auth token for registry', registry);
 
 		// Try and update the .npmrc file
-		updateNpmrc(formUrlToken(registry, tokenEnvName), registry)
-			.then(msg => {
-				resolve(msg);
-			})
-			.catch(err => {
-				reject(err);
-			});
-	});
+		const msg = await updateNpmrc(formUrlToken(registry, tokenEnvName), registry);
+		return msg;
+	} catch (err) {
+		throw err;
+	}
 }
 
 module.exports = setAuthToken;

--- a/lib/js/_utils/__mocks__/_get-latest-version.js
+++ b/lib/js/_utils/__mocks__/_get-latest-version.js
@@ -12,19 +12,14 @@
  * @param {String} packageName name of package to check
  * @return {Promise<String>}
  */
-function getLatestVersion(name) {
-	return new Promise((resolve, reject) => {
-		process.nextTick(
-			() => {
-				if ((name === 'global-error')) {
-					reject(new Error('error thrown'));
-				}
-				if ((name === 'global-unpublished')) {
-					resolve(null);
-				}
-				resolve('2.0.0');
-			});
-	});
+async function getLatestVersion(name) {
+	if ((name === 'global-error')) {
+		throw new Error('error thrown');
+	}
+	if ((name === 'global-unpublished')) {
+		return null;
+	}
+	return '2.0.0';
 }
 
 module.exports = getLatestVersion;

--- a/lib/js/_utils/__mocks__/_npm-registry-request.js
+++ b/lib/js/_utils/__mocks__/_npm-registry-request.js
@@ -16,25 +16,21 @@ const packageResponse = {
 };
 
 // Pass the mocked response
-function get(uri, params, cb) {
+async function get(uri) {
 	if (uri === 'empty' || uri === 'valid') {
-		cb(null, packageResponse[uri]);
-	} else {
-		cb(new Error('error thrown'), undefined);
+		return packageResponse[uri];
 	}
+	throw new Error('error thrown');
 }
 
 // Mock the NPM registry
-function npmRegistryRequest(type) {
-	return new Promise((resolve, reject) => {
-		get(type, {}, (error, data) => {
-			process.nextTick(
-				() => (typeof data !== 'object' && error) ?
-					reject(error) :
-					resolve(data)
-			);
-		});
-	});
+async function npmRegistryRequest(type) {
+	try {
+		const data = await get(type);
+		return data;
+	} catch (err)  {
+		throw err;
+	}
 }
 
 module.exports = npmRegistryRequest;

--- a/lib/js/_utils/__mocks__/_npm-registry-request.js
+++ b/lib/js/_utils/__mocks__/_npm-registry-request.js
@@ -28,7 +28,7 @@ async function npmRegistryRequest(type) {
 	try {
 		const data = await get(type);
 		return data;
-	} catch (err)  {
+	} catch (err) {
 		throw err;
 	}
 }

--- a/lib/js/_utils/_check-exists.js
+++ b/lib/js/_utils/_check-exists.js
@@ -5,39 +5,41 @@
 'use strict';
 
 const fs = require('fs');
+const util = require('util');
 
-function checkExists(path, isFile) {
-	return new Promise((resolve, reject) => {
-		fs.stat(path, (err, stats) => {
-			if (err) {
-				reject(new Error(`Not found \`${path}\``));
-			} else {
-				if (
-					(isFile && stats.isFile()) ||
-					(!isFile && stats.isDirectory())
-				) {
-					resolve(path);
-				}
-				reject(new Error(`Not a ${isFile ? 'file' : 'directory'} \`${path}\``));
-			}
-		});
-	});
+const stat = util.promisify(fs.stat);
+
+async function checkExists(path, isFile) {
+	try {
+		const stats = await stat(path);
+
+		if (
+			(isFile && !stats.isFile()) ||
+			(!isFile && !stats.isDirectory())
+		) {
+			throw new Error(`Not a ${isFile ? 'file' : 'directory'} \`${path}\``);
+		}
+	} catch (err) {
+		throw new Error(`Not found \`${path}\``);
+	}
 }
 
-function fileExists(path) {
-	return new Promise((resolve, reject) => {
-		checkExists(path, true)
-			.then(path => resolve(path))
-			.catch(err => reject(err));
-	});
+async function fileExists(path) {
+	try {
+		await checkExists(path, true);
+		return path;
+	} catch (err) {
+		throw err;
+	}
 }
 
-function directoryExists(path) {
-	return new Promise((resolve, reject) => {
-		checkExists(path, false)
-			.then(path => resolve(path))
-			.catch(err => reject(err));
-	});
+async function directoryExists(path) {
+	try {
+		await checkExists(path, false);
+		return path;
+	} catch (err) {
+		throw err;
+	}
 }
 
 module.exports = {

--- a/lib/js/_utils/_extend-package.js
+++ b/lib/js/_utils/_extend-package.js
@@ -9,65 +9,63 @@ const extender = require('@springernature/util-package-extender');
 const reporter = require('@springernature/util-cli-reporter');
 
 // Publish package that extends another package
-function publish(scope, packagePath) {
-	return new Promise((resolve, reject) => {
+async function publish(scope, packagePath) {
+	try {
 		const packageJsonPath = path.resolve(packagePath, 'package.json');
 		const packageJson = require(packageJsonPath);
 		const extendPackage = Boolean(packageJson.extendsPackage);
 
 		// Extension status
-		reporter.info('extended package', extendPackage, (extendPackage) ? packageJson.extendsPackage : '');
+		reporter.info('extended package', extendPackage.toString(), (extendPackage) ? packageJson.extendsPackage : '');
 
 		// Early return if not extended package
 		if (!extendPackage) {
-			resolve();
 			return;
 		}
 
 		// Get extension details
-		extender.getPackageExtensionDetails(packageJson, scope)
-			.then(packageExtensionDetails => {
-				// Extend package
-				extender.extendPackage(
-					packagePath,
-					packageExtensionDetails.remotePackage,
-					packageExtensionDetails.localPackage
-				).then(resolve);
-			}).catch(err => reject(err));
-	});
+		const packageExtensionDetails = await extender.getPackageExtensionDetails(packageJson, scope);
+
+		// Extend package
+		await extender.extendPackage(
+			packagePath,
+			packageExtensionDetails.remotePackage,
+			packageExtensionDetails.localPackage
+		);
+	} catch (err) {
+		throw err;
+	}
 }
 
 // Validate package that extends another package
-function validate(config, packagePath) {
-	return new Promise((resolve, reject) => {
+async function validate(config, packagePath) {
+	try {
 		const packageJsonPath = path.resolve(packagePath, 'package.json');
 		const packageJson = require(packageJsonPath);
 		const extendPackage = Boolean(packageJson.extendsPackage);
 
 		// Extension status
-		reporter.info('extended package', extendPackage, (extendPackage) ? packageJson.extendsPackage : '');
+		reporter.info('extended package', extendPackage.toString(), (extendPackage) ? packageJson.extendsPackage : '');
 
 		// Early return if not extended package
 		if (!extendPackage) {
-			resolve();
 			return;
 		}
 
 		// Is extension allowed via package-manager config
 		if (!config.allowExtends) {
-			reject(new Error('Package extension disabled for this repository'));
-			return;
+			throw new Error('Package extension disabled for this repository');
 		}
 
 		// Check extension details
-		extender.getPackageExtensionDetails(packageJson, config.scope)
-			.then(packageExtensionDetails => {
-				if (packageExtensionDetails.extendPackage) {
-					reporter.success('validating', 'remote package dependency', packageExtensionDetails.remotePackage);
-				}
-				resolve();
-			}).catch(err => reject(err));
-	});
+		const packageExtensionDetails = await extender.getPackageExtensionDetails(packageJson, config.scope);
+
+		if (packageExtensionDetails.extendPackage) {
+			reporter.success('validating', 'remote package dependency', packageExtensionDetails.remotePackage);
+		}
+	} catch (err) {
+		throw err;
+	}
 }
 
 module.exports = {

--- a/lib/js/_validate/_check-changed-files.js
+++ b/lib/js/_validate/_check-changed-files.js
@@ -10,18 +10,18 @@ const reporter = require('@springernature/util-cli-reporter');
 const getPackageName = require('../_utils/_get-package-name');
 const checkPublishFile = require('./_check-publish-file');
 
-function checkFiles(packagePath, changedFiles, changelogName) {
+async function checkFiles(packagePath, changedFiles, changelogName) {
 	const packageName = getPackageName(packagePath);
 	const changelogFile = `${packageName}/${changelogName}`;
 	const packagefile = `${packageName}/package.json`;
 
-	return new Promise((resolve, reject) => {
+	try {
 		reporter.info('updated files', changedFiles.split('\n').join(', '));
-		checkPublishFile(changedFiles, changelogFile)
-			.then(() => checkPublishFile(changedFiles, packagefile))
-			.then(resolve)
-			.catch(err => reject(err));
-	});
+		await checkPublishFile(changedFiles, changelogFile);
+		await checkPublishFile(changedFiles, packagefile);
+	} catch (err) {
+		throw err;
+	}
 }
 
 module.exports = checkFiles;

--- a/lib/js/_validate/_check-license.js
+++ b/lib/js/_validate/_check-license.js
@@ -6,19 +6,18 @@
 
 const reporter = require('@springernature/util-cli-reporter');
 
-function validLicense(packagePath, globalLicense) {
-	return new Promise((resolve, reject) => {
-		const packageLicense = require(`${packagePath}/package.json`).license;
-		const validates = packageLicense && packageLicense === globalLicense;
+async function validLicense(packagePath, globalLicense) {
+	const packageLicense = require(`${packagePath}/package.json`).license;
+	const validates = packageLicense && packageLicense === globalLicense;
 
-		reporter[(validates) ? 'success' : 'fail']('validating', 'license', packageLicense);
+	// Report status
+	reporter[(validates) ? 'success' : 'fail']('validating', 'license', packageLicense);
 
-		if (validates) {
-			resolve();
-		} else {
-			reject(new Error(`Invalid license \`${packageLicense}\`. Should be \`${globalLicense}\``));
-		}
-	});
+	if (validates) {
+		return;
+	}
+
+	throw new Error(`Invalid license \`${packageLicense}\`. Should be \`${globalLicense}\``);
 }
 
 module.exports = validLicense;

--- a/lib/js/_validate/_check-naming.js
+++ b/lib/js/_validate/_check-naming.js
@@ -15,31 +15,33 @@ function checkName(name, re) {
 }
 
 // Return a promise based on naming validation
-function validNaming(config, packagePath) {
-	return new Promise((resolve, reject) => {
-		const startsWith = (config.prefix) ? `${config.prefix}-` : '';
-		const folderName = getPackageName(packagePath);
-		const packageName = require(`${packagePath}/package.json`).name;
-		const validFolder = checkName(folderName, new RegExp(`^${startsWith}`));
-		const validPackage = checkName(packageName, new RegExp(`^@${config.scope}/${startsWith}`));
-		const validates = validFolder && validPackage;
+async function validNaming(config, packagePath) {
+	const startsWith = (config.prefix) ? `${config.prefix}-` : '';
+	const folderName = getPackageName(packagePath);
+	const packageName = require(`${packagePath}/package.json`).name;
+	const validFolder = checkName(folderName, new RegExp(`^${startsWith}`));
+	const validPackage = checkName(packageName, new RegExp(`^@${config.scope}/${startsWith}`));
+	const validates = validFolder && validPackage;
 
-		const packagesFolderName = path.resolve(process.cwd(), config.packagesDirectory)
-			.split(path.sep)
-			.pop();
+	const packagesFolderName = path.resolve(process.cwd(), config.packagesDirectory)
+		.split(path.sep)
+		.pop();
 
-		reporter.title(`${packagesFolderName}/${folderName}`);
-		reporter[(validFolder) ? 'success' : 'fail']('validating', folderName, (validFolder) ? 'valid folder name' : 'invalid folder name');
-		reporter[(validPackage) ? 'success' : 'fail']('validating', packageName, (validPackage) ? 'valid package name' : 'invalid package name');
+	reporter.title(`${packagesFolderName}/${folderName}`);
+	reporter[(validFolder) ? 'success' : 'fail']('validating', folderName, (validFolder) ? 'valid folder name' : 'invalid folder name');
+	reporter[(validPackage) ? 'success' : 'fail']('validating', packageName, (validPackage) ? 'valid package name' : 'invalid package name');
 
-		if (validates) {
-			resolve();
-		} else if (!validFolder) {
-			reject(new Error(`Invalid folder name: ${folderName}`));
-		} else if (!validPackage) {
-			reject(new Error(`Invalid package name: ${packageName}`));
-		}
-	});
+	if (validates) {
+		return;
+	}
+
+	if (!validFolder) {
+		throw new Error(`Invalid folder name: ${folderName}`);
+	}
+
+	if (!validPackage) {
+		throw new Error(`Invalid package name: ${packageName}`);
+	}
 }
 
 module.exports = validNaming;

--- a/lib/js/_validate/_check-publish-file.js
+++ b/lib/js/_validate/_check-publish-file.js
@@ -6,19 +6,16 @@
 
 const reporter = require('@springernature/util-cli-reporter');
 
-function checkPublishFile(changedFiles, file) {
-	return new Promise((resolve, reject) => {
-		const found = changedFiles.split('\n').findIndex(element => {
-			return element.includes(file);
-		});
-
-		if (found === -1) {
-			reject(new Error(`${file} file must be updated`));
-		} else {
-			reporter.success('updated', file);
-			resolve();
-		}
+async function checkPublishFile(changedFiles, file) {
+	const found = changedFiles.split('\n').findIndex(element => {
+		return element.includes(file);
 	});
+
+	if (found === -1) {
+		throw new Error(`${file} file must be updated`);
+	}
+
+	reporter.success('updated', file);
 }
 
 module.exports = checkPublishFile;


### PR DESCRIPTION
- Tidy up the code by converting `Promise` to `Async/Await` where possible
- Fix a bug in `_publish/_publish-to-npm.js` where the path to the toolkit needs to be reset after attempting publication now that we are looking through multiple toolkits