### PR TITLE
BUG: Auth Token

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.0.1 (2019-11-05)
+	* BUG: null being passed for token access instead of NPM_TOKEN
+
 ## 4.0.0 (2019-10-31)
 	* BREAKING: Major rewrite that requires a change to repo structures
 		* Handles multiple toolkits per repo

--- a/lib/js/_publish/_publish-to-npm.js
+++ b/lib/js/_publish/_publish-to-npm.js
@@ -23,7 +23,7 @@ async function publishToNpm(pathToPackage, rootPath) {
 	reporter.info('switching to package dir', process.cwd());
 
 	// Set the auth token
-	const message = await setAuthToken(pathToPackage, null);
+	const message = await setAuthToken(pathToPackage);
 	reporter.info(message.description, message.text);
 
 	// Publish package

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@springernature/frontend-package-manager",
   "description": "handles the creation, validation, and publication of packages",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "LGPL-3.0",
   "keywords": [
     "node",


### PR DESCRIPTION
Fixes a bug where null is being passed to the function the retrieves the NPM Auth token from travis, which meant that packages couldn't publish