### PR TITLE
Ignore package-lock.json files when validating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,11 +36,11 @@ bower_components
 build/Release
 
 # Dependency directories
-node_modules/
-jspm_packages/
+node_modules
+jspm_packages
 
 # TypeScript v1 declaration files
-typings/
+typings
 
 # Optional npm cache directory
 .npm
@@ -64,5 +64,5 @@ typings/
 .next
 
 # IDE
-/.idea/
+/.idea
 *.iml

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 4.0.2 (2019-11-06)
+	* BUG: package level package-lock.json files not being ignored during validation
+
 ## 4.0.1 (2019-11-05)
 	* BUG: null being passed for token access instead of NPM_TOKEN
 

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -36,6 +36,7 @@ const defaultPackageContents = {
 const __fsMockFiles = () => {
 	return {
 		'packages/package/pass': defaultPackageContents,
+		'packages/package/passWithBuildFiles': {...defaultPackageContents, ...{'package-lock.json': 'file content'}},
 		'packages/package/passGitIgnore': defaultPackageContents,
 		'packages/package/passDotfiles': defaultPackageContents,
 		'packages/package/failIsRequired': defaultPackageContents,

--- a/__mocks__/gitignore-globs.js
+++ b/__mocks__/gitignore-globs.js
@@ -5,5 +5,5 @@
 'use strict';
 
 module.exports = () => {
-	return ['**/folder3', '**/folder3/**'];
+	return ['**/folder3', '**/folder3/**', '**/packages/**/package-lock.json'];
 };

--- a/__mocks__/gitignore-globs.js
+++ b/__mocks__/gitignore-globs.js
@@ -5,5 +5,5 @@
 'use strict';
 
 module.exports = () => {
-	return ['folder3'];
+	return ['**/folder3', '**/folder3/**'];
 };

--- a/__mocks__/glob-results.js
+++ b/__mocks__/glob-results.js
@@ -64,6 +64,21 @@ const packageFiles = () => {
 			'packages/package/passGitIgnore/folder3/file.scss',
 			'packages/package/passGitIgnore/folder3/file.js'
 		],
+		'packages/package/passWithBuildFiles/**/*': [
+			'packages/package/passWithBuildFiles/required.md',
+			'packages/package/passWithBuildFiles/package-lock.json',
+			'packages/package/passWithBuildFiles/folder1',
+			'packages/package/passWithBuildFiles/folder1/file.scss',
+			'packages/package/passWithBuildFiles/folder1/file.css',
+			'packages/package/passWithBuildFiles/folder2',
+			'packages/package/passWithBuildFiles/folder2/file.js',
+			'packages/package/passWithBuildFiles/folder2/file.json',
+			'packages/package/passWithBuildFiles/folder2/subfolder',
+			'packages/package/passWithBuildFiles/folder2/subfolder/file.js',
+			'packages/package/passWithBuildFiles/folder3',
+			'packages/package/passWithBuildFiles/folder3/file.scss',
+			'packages/package/passWithBuildFiles/folder3/file.js'
+		],
 		'packages/package/passDotfiles/**/*': [
 			'packages/package/passDotfiles/required.md',
 			'packages/package/passDotfiles/.adotfile',

--- a/__tests__/unit/_validate/check-package-structure.test.js
+++ b/__tests__/unit/_validate/check-package-structure.test.js
@@ -42,21 +42,21 @@ describe('Check validation', () => {
 		).rejects.toThrowError(new Error('globby error'));
 	});
 
-	test('Resolves when filesystem matches config', async () => {
+	test('Resolves when filesystem matches validationConfig', async () => {
 		expect.assertions(1);
 		await expect(
 			checkValidation(validationConfig, 'packages/package/pass')
 		).resolves.toEqual();
 	});
 
-	test('Resolves when filesystem matches config ignore files in .gitignore', async () => {
+	test('Resolves when filesystem matches validationConfig & ignores files in .gitignore', async () => {
 		expect.assertions(1);
 		await expect(
 			checkValidation(validationConfig, 'packages/package/passGitIgnore')
 		).resolves.toEqual();
 	});
 
-	test('Resolves when filesystem matches config ignore build files', async () => {
+	test('Resolves when filesystem matches validationConfig & ignores any package lock files', async () => {
 		expect.assertions(1);
 		await expect(
 			checkValidation(validationConfig, 'packages/package/passWithBuildFiles')
@@ -98,14 +98,14 @@ describe('Check validation', () => {
 		).rejects.toThrowError(new Error('Invalid files or folders in failIsTopLevelFile'));
 	});
 
-	test('Resolves with any folders when no folder config', async () => {
+	test('Resolves with any folders when no folders specified in config', async () => {
 		expect.assertions(1);
 		await expect(
 			checkValidation(validationConfigNoFolders, 'packages/package/failIsFolder')
 		).resolves.toEqual();
 	});
 
-	test('Resolves with any files when no folder config', async () => {
+	test('Resolves with any files when no folders specified in config', async () => {
 		expect.assertions(1);
 		await expect(
 			checkValidation(validationConfigNoFolders, 'packages/package/failIsFileType')

--- a/__tests__/unit/_validate/check-package-structure.test.js
+++ b/__tests__/unit/_validate/check-package-structure.test.js
@@ -56,6 +56,13 @@ describe('Check validation', () => {
 		).resolves.toEqual();
 	});
 
+	test('Resolves when filesystem matches config ignore build files', async () => {
+		expect.assertions(1);
+		await expect(
+			checkValidation(validationConfig, 'packages/package/passWithBuildFiles')
+		).resolves.toEqual();
+	});
+
 	test('Rejects when required file missing', async () => {
 		expect.assertions(1);
 		await expect(

--- a/lib/js/_validate/_check-package-structure.js
+++ b/lib/js/_validate/_check-package-structure.js
@@ -17,10 +17,28 @@ const getPackageName = require('../_utils/_get-package-name');
 
 const gitignorePath = path.resolve(process.cwd(), '.gitignore');
 
+// https://github.com/regexhq/dotfile-regex/blob/master/index.js
+const dotfileRegex = /(?:^|[\\\/])(\.(?!\.)[^\\\/]+)$/; // eslint-disable-line no-useless-escape
+
 let config;
 let configFolders;
 let requiredFiles;
 let results;
+
+/**
+ * Check if a file/folder matches any files excluded from validation
+ * Allows partial matches on the end of the path to cater for cwd
+ * Returns true if match found
+ * @private
+ * @function filterExcludedFiles
+ * @param {String} localPath path to a file or folder to check
+ * @param {Array} excludedFiles Array of file paths to exclude from validation
+ * @return {Boolean}
+ */
+function filterExcludedFiles(localPath, excludedFiles) {
+	const matchedArray = excludedFiles.filter(excludedItem => localPath.endsWith(excludedItem));
+	return matchedArray.length > 0;
+}
 
 /**
  * Check if a glob item is a required file or the changelog
@@ -116,7 +134,6 @@ function isFileType(relativeFilePath) {
 
 /**
  * Filter glob results
- * - Remove directory string
  * - Remove paths matching .gitignore'd files
  * - Remove dotfiles
  * @private
@@ -125,9 +142,6 @@ function isFileType(relativeFilePath) {
  * @return {Array}
  */
 function getFilteredResults(files) {
-	// https://github.com/regexhq/dotfile-regex/blob/master/index.js
-	const dotfileRegex = /(?:^|[\\\/])(\.(?!\.)[^\\\/]+)$/; // eslint-disable-line no-useless-escape
-
 	// Generate array of glob patterns from .gitignore
 	const globs = gitParse(gitignorePath);
 
@@ -136,7 +150,7 @@ function getFilteredResults(files) {
 
 	// Generate a list of files to exclude from validation
 	// Make file paths relative for generation to match minimatch pattern
-	const exclude = files
+	const excludedFiles = files
 		.map(filePath => path.relative(process.cwd(), filePath))
 		.filter(
 			minimatch.filter(pattern,
@@ -145,13 +159,12 @@ function getFilteredResults(files) {
 					dot: true
 				}
 			)
-		)
-		.map(localPath => path.resolve(process.cwd(), localPath));
+		);
 
-	// filter out dot files and ignored files
+	// filter out dot files and excluded files
 	const result = files
-		.filter(element => !dotfileRegex.test(element))
-		.filter(element => !exclude.includes(element));
+		.filter(localPath => !dotfileRegex.test(localPath))
+		.filter(localPath => !filterExcludedFiles(localPath, excludedFiles));
 
 	return result;
 }

--- a/lib/js/_validate/_check-package-structure.js
+++ b/lib/js/_validate/_check-package-structure.js
@@ -26,17 +26,17 @@ let results;
  * Check if a glob item is a required file or the changelog
  * @private
  * @function isRequired
- * @param {String} item name of file
+ * @param {String} relativeFilePath relative file/folder name
  * @return {Boolean}
  */
-function isRequired(item) {
-	const required = requiredFiles.includes(item) || item === config.changelog;
+function isRequired(relativeFilePath) {
+	const required = requiredFiles.includes(relativeFilePath) || relativeFilePath === config.changelog;
 
 	if (required) {
-		reporter.success('validating', item, 'exists');
-		if (item !== config.changelog) {
+		reporter.success('validating', relativeFilePath, 'exists');
+		if (relativeFilePath !== config.changelog) {
 			requiredFiles.splice(requiredFiles.findIndex(element => {
-				return element === item;
+				return element === relativeFilePath;
 			}), 1);
 		}
 	}
@@ -49,19 +49,19 @@ function isRequired(item) {
  * If configFolders not set in config, all folders valid
  * @private
  * @function isFolder
- * @param {String} directory root path of the package
- * @param {String} item path to a file
+ * @param {String} filePath full path to item
+ * @param {String} relativeFilePath relative file/folder name
  * @return {Boolean}
  */
-function isFolder(directory, item) {
-	const folder = fs.lstatSync(path.resolve(directory, item)).isDirectory();
+function isFolder(filePath, relativeFilePath) {
+	const isDirectory = fs.lstatSync(filePath).isDirectory();
 
-	if (folder) {
-		const splitGlob = item.split('/');
+	if (isDirectory) {
+		const splitGlob = relativeFilePath.split('/');
 		const isValid = (configFolders) ? configFolders.includes(splitGlob[0]) : true;
 
 		reporter[(isValid) ? 'success' : 'fail'](
-			'validating', item, (isValid) ?
+			'validating', relativeFilePath, (isValid) ?
 				'is a valid folder' :
 				'is not a valid folder'
 		);
@@ -80,11 +80,12 @@ function isFolder(directory, item) {
  * Check if glob item is a valid file within a valid folder
  * @private
  * @function isFileType
- * @param {String} item path to a file
+ * @param {String} relativeFilePath relative file/folder name
  * @return {Boolean}
  */
-function isFileType(item) {
-	const splitGlob = item.split('/');
+function isFileType(relativeFilePath) {
+	const splitGlob = relativeFilePath.split('/');
+
 	if (splitGlob.length > 1) {
 		const topLevelFolder = splitGlob[0];
 		const fileNameSplit = splitGlob[splitGlob.length - 1].split('.');
@@ -92,13 +93,13 @@ function isFileType(item) {
 
 		if (!configFolders) {
 			// Folders config not set, any files/folders allowed
-			reporter.success('validating', item, `is a valid file in ${topLevelFolder}`);
+			reporter.success('validating', relativeFilePath, `is a valid file in ${topLevelFolder}`);
 		} else if (configFolders.includes(topLevelFolder)) {
 			// Is a valid extension within a valid folder?
 			const isValid = config.folders[topLevelFolder].includes(extension);
 
 			reporter[(isValid) ? 'success' : 'fail'](
-				'validating', item, (isValid) ?
+				'validating', relativeFilePath, (isValid) ?
 					`is a valid file in ${topLevelFolder}` :
 					`is not a valid file in ${topLevelFolder}`
 			);
@@ -121,37 +122,34 @@ function isFileType(item) {
  * - Remove dotfiles
  * @private
  * @function getFilteredResults
- * @param {String} directory path to files
  * @param {Array} files file list to filter
  * @return {Array}
  */
-function getFilteredResults(directory, files) {
-	const packageLevelLockFiles = '**/package-lock.json';
-	const globs = gitParse(gitignorePath);
-
-	// Add package level lock files to gitignore paths
-	// Not covered by current gitignore path as the
-	// working directory has changed
-	globs.push(packageLevelLockFiles);
-
-	// Generate a pattern matching string
-	let pattern = (globs.length > 1) ? `{${globs.join()}}` : globs[0];
-
-	// Filter directory from file paths
-	files = files.map(pathAndFile => pathAndFile.replace(`${directory}/`, ''));
-
-	// Remove paths matching ignored files
-	const exclude = files.filter(
-		minimatch.filter(pattern,
-			{
-				matchBase: true,
-				dot: true
-			}
-		)
-	);
-
+function getFilteredResults(files) {
 	// https://github.com/regexhq/dotfile-regex/blob/master/index.js
 	const dotfileRegex = /(?:^|[\\\/])(\.(?!\.)[^\\\/]+)$/; // eslint-disable-line no-useless-escape
+
+	// Generate array of glob patterns from .gitignore
+	const globs = gitParse(gitignorePath);
+
+	// Generate a pattern matching string from parsed .gitignore
+	const pattern = (globs.length > 1) ? `{${globs.join()}}` : globs[0];
+
+	// Generate a list of files to exclude from validation
+	// Make file paths relative for generation to match minimatch pattern
+	const exclude = files
+		.map(path => path.replace(`${process.cwd()}/`, ''))
+		.filter(
+			minimatch.filter(pattern,
+				{
+					matchBase: true,
+					dot: true
+				}
+			)
+		)
+		.map(localPath => `${process.cwd()}/${localPath}`);
+
+	// filter out dot files and ignored files
 	const result = files
 		.filter(element => !dotfileRegex.test(element))
 		.filter(element => !exclude.includes(element));
@@ -165,20 +163,21 @@ function getFilteredResults(directory, files) {
  * @async
  * @function checkPackageStructure
  * @param {String} packagePath package path on filesystem
+ * @param {String} packageName name of the package to check
  * @return {Promise}
  */
-async function checkPackageStructure(packagePath) {
-	const packageName = getPackageName(packagePath);
-
+async function checkPackageStructure(packagePath, packageName) {
 	try {
 		const files = await globby(`${packagePath}/**/*`, {onlyFiles: false});
-		const filteredResults = getFilteredResults(packagePath, files);
+		const filteredResults = getFilteredResults(files);
 
 		// Validate files and folders
-		for (const value of filteredResults) {
-			if (!isRequired(value) && !isFolder(packagePath, value) && !isFileType(value)) {
+		for (const filePath of filteredResults) {
+			const relativeFilePath = path.relative(packagePath, filePath);
+
+			if (!isRequired(relativeFilePath) && !isFolder(filePath, relativeFilePath) && !isFileType(relativeFilePath)) {
 				// If not recongnised at any other step then invalid top level file
-				reporter.fail('validating', value, 'is not a valid file');
+				reporter.fail('validating', relativeFilePath, 'is not a valid file');
 				results.topLevel = false;
 			}
 		}
@@ -205,10 +204,9 @@ async function checkPackageStructure(packagePath) {
  * @function init
  * @param {Object} validationConfig options for this package
  * @param {String} packagePath package path on filesystem
- * @param {Object} options passed for glob search
  * @return {Promise}
  */
-async function init(validationConfig, packagePath, options) {
+async function init(validationConfig, packagePath) {
 	config = validationConfig;
 	configFolders = (config.folders) ? Object.keys(config.folders) : undefined;
 	requiredFiles = JSON.parse(JSON.stringify(config.required));
@@ -219,7 +217,7 @@ async function init(validationConfig, packagePath, options) {
 		topLevel: true
 	}));
 
-	await checkPackageStructure(packagePath, options);
+	await checkPackageStructure(packagePath, getPackageName(packagePath));
 }
 
 module.exports = init;

--- a/lib/js/_validate/_check-package-structure.js
+++ b/lib/js/_validate/_check-package-structure.js
@@ -145,7 +145,8 @@ function removeNonValidatedPaths(filePaths) {
 	const globs = gitParse(gitignorePath);
 
 	// Generate a pattern matching string from parsed .gitignore
-	// Example: {**/a,b*,*.js}
+	// Single pattern example: **/a
+	// Multiple pattern example: {**/a,b*,*.js}
 	const pattern = (globs.length > 1) ? `{${globs.join()}}` : globs[0];
 
 	// Generate a list of files to exclude from validation

--- a/lib/js/_validate/_check-package-structure.js
+++ b/lib/js/_validate/_check-package-structure.js
@@ -30,14 +30,13 @@ let results;
  * Allows partial matches on the end of the path to cater for cwd
  * Returns true if match found
  * @private
- * @function filterExcludedFiles
+ * @function isExcludedPath
  * @param {String} localPath path to a file or folder to check
  * @param {Array} excludedFiles Array of file paths to exclude from validation
  * @return {Boolean}
  */
-function filterExcludedFiles(localPath, excludedFiles) {
-	const matchedArray = excludedFiles.filter(excludedItem => localPath.endsWith(excludedItem));
-	return matchedArray.length > 0;
+function isExcludedPath(localPath, excludedFiles) {
+	return excludedFiles.some(excludedItem => localPath.endsWith(excludedItem));
 }
 
 /**
@@ -133,24 +132,25 @@ function isFileType(relativeFilePath) {
 }
 
 /**
- * Filter glob results
+ * Filter glob results to remove files not being validated
  * - Remove paths matching .gitignore'd files
  * - Remove dotfiles
  * @private
- * @function getFilteredResults
- * @param {Array} files file list to filter
+ * @function removeNonValidatedPaths
+ * @param {Array} filePaths file list to filter
  * @return {Array}
  */
-function getFilteredResults(files) {
+function removeNonValidatedPaths(filePaths) {
 	// Generate array of glob patterns from .gitignore
 	const globs = gitParse(gitignorePath);
 
 	// Generate a pattern matching string from parsed .gitignore
+	// Example: {**/a,b*,*.js}
 	const pattern = (globs.length > 1) ? `{${globs.join()}}` : globs[0];
 
 	// Generate a list of files to exclude from validation
 	// Make file paths relative for generation to match minimatch pattern
-	const excludedFiles = files
+	const excludedFiles = filePaths
 		.map(filePath => path.relative(process.cwd(), filePath))
 		.filter(
 			minimatch.filter(pattern,
@@ -162,9 +162,9 @@ function getFilteredResults(files) {
 		);
 
 	// filter out dot files and excluded files
-	const result = files
+	const result = filePaths
 		.filter(localPath => !dotfileRegex.test(localPath))
-		.filter(localPath => !filterExcludedFiles(localPath, excludedFiles));
+		.filter(localPath => !isExcludedPath(localPath, excludedFiles));
 
 	return result;
 }
@@ -180,11 +180,11 @@ function getFilteredResults(files) {
  */
 async function checkPackageStructure(packagePath, packageName) {
 	try {
-		const files = await globby(`${packagePath}/**/*`, {onlyFiles: false});
-		const filteredResults = getFilteredResults(files);
+		const filePaths = await globby(`${packagePath}/**/*`, {onlyFiles: false});
+		const pathsToValidate = removeNonValidatedPaths(filePaths);
 
 		// Validate files and folders
-		for (const filePath of filteredResults) {
+		for (const filePath of pathsToValidate) {
 			const relativeFilePath = path.relative(packagePath, filePath);
 
 			if (!isRequired(relativeFilePath) && !isFolder(filePath, relativeFilePath) && !isFileType(relativeFilePath)) {

--- a/lib/js/_validate/_check-package-structure.js
+++ b/lib/js/_validate/_check-package-structure.js
@@ -126,10 +126,21 @@ function isFileType(item) {
  * @return {Array}
  */
 function getFilteredResults(directory, files) {
+	const packageLevelLockFiles = '**/package-lock.json';
 	const globs = gitParse(gitignorePath);
-	const pattern = (globs.length > 1) ? `{${globs.join(',')}}` : globs[0];
+
+	// Add package level lock files to gitignore paths
+	// Not covered by current gitignore path as the
+	// working directory has changed
+	globs.push(packageLevelLockFiles);
+
+	// Generate a pattern matching string
+	let pattern = (globs.length > 1) ? `{${globs.join()}}` : globs[0];
+
+	// Filter directory from file paths
 	files = files.map(pathAndFile => pathAndFile.replace(`${directory}/`, ''));
 
+	// Remove paths matching ignored files
 	const exclude = files.filter(
 		minimatch.filter(pattern,
 			{

--- a/lib/js/_validate/_check-package-structure.js
+++ b/lib/js/_validate/_check-package-structure.js
@@ -84,19 +84,18 @@ function isFolder(filePath, relativeFilePath) {
  * @return {Boolean}
  */
 function isFileType(relativeFilePath) {
-	const splitGlob = relativeFilePath.split('/');
+	const splitGlob = relativeFilePath.split(path.sep);
 
 	if (splitGlob.length > 1) {
 		const topLevelFolder = splitGlob[0];
-		const fileNameSplit = splitGlob[splitGlob.length - 1].split('.');
-		const extension = fileNameSplit[fileNameSplit.length - 1];
+		const fileType = path.extname(relativeFilePath).slice(1);
 
 		if (!configFolders) {
 			// Folders config not set, any files/folders allowed
 			reporter.success('validating', relativeFilePath, `is a valid file in ${topLevelFolder}`);
 		} else if (configFolders.includes(topLevelFolder)) {
 			// Is a valid extension within a valid folder?
-			const isValid = config.folders[topLevelFolder].includes(extension);
+			const isValid = config.folders[topLevelFolder].includes(fileType);
 
 			reporter[(isValid) ? 'success' : 'fail'](
 				'validating', relativeFilePath, (isValid) ?
@@ -138,7 +137,7 @@ function getFilteredResults(files) {
 	// Generate a list of files to exclude from validation
 	// Make file paths relative for generation to match minimatch pattern
 	const exclude = files
-		.map(path => path.replace(`${process.cwd()}/`, ''))
+		.map(filePath => path.relative(process.cwd(), filePath))
 		.filter(
 			minimatch.filter(pattern,
 				{
@@ -147,7 +146,7 @@ function getFilteredResults(files) {
 				}
 			)
 		)
-		.map(localPath => `${process.cwd()}/${localPath}`);
+		.map(localPath => path.resolve(process.cwd(), localPath));
 
 	// filter out dot files and ignored files
 	const result = files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/frontend-package-manager",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/frontend-package-manager",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/frontend-package-manager",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@springernature/frontend-package-manager",
   "description": "handles the creation, validation, and publication of packages",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "license": "LGPL-3.0",
   "keywords": [
     "node",


### PR DESCRIPTION
Fixes a small bug when validating packages on the command line.

When running tests for a package within a toolkit, you need to install any dependencies before running the tests (this can be done with [this command](https://github.com/springernature/frontend-toolkits/blob/master/package.json#L22)). This creates a `package-lock.json` file within the package.

We [don't want to commit these files](https://www.twilio.com/blog/lockfiles-nodejs), so we exclude them in our [`.gitignore` file](https://github.com/springernature/frontend-toolkits/blob/master/.gitignore#L67).

When validating our packages, the package manager parses that `.gitignore` file and does not run the validator on the filepaths generated.

There was a bug where the package level lock files were still being validated (and throwing errors) because the current working directory changes when validating packages. This also caused problems in testing because of the way the filesystem gets mocked in Jest.

This update:
* Refactors the code to fix this issue and also allows for better, more robust testing.
* Refactors some of the variable naming to better explain their function