### PR TITLE
Allow Brand Level README.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The context package accepts the following default configuration which can be ext
 }
 ```
 
-In addition to the configuration options defined for regular packages, the context package accepts the following additional configuration items:
+In addition to the configuration options defined for regular packages, the context package allows an _additional_ `README.md` file within each brand folder e.g. `name-of-context-package/brand-name/README.md`, as well as the following additional configuration items:
 
 #### contextDirectory
 

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -45,6 +45,8 @@ const __fsMockFiles = () => {
 		'packages/package/passDotfiles': defaultPackageContents,
 		'packages/package/passContext': {'required.md': 'file content', 'HISTORY.md': 'file content'},
 		'packages/package/passContext/brandA': defaultFolders,
+		'packages/package/passContextWithReadme': {'required.md': 'file content', 'HISTORY.md': 'file content'},
+		'packages/package/passContextWithReadme/brandA': {...defaultFolders, ...{'README.md': 'file content'}},
 		'packages/package/failIsRequired': defaultPackageContents,
 		'packages/package/failIsFolder': defaultPackageContents,
 		'packages/package/failIsFileType': defaultPackageContents,

--- a/__mocks__/glob-results.js
+++ b/__mocks__/glob-results.js
@@ -152,6 +152,22 @@ const packageFiles = {
 		'packages/package/passContext/brandA/folder2/file.json',
 		'packages/package/passContext/brandA/folder2/subfolder',
 		'packages/package/passContext/brandA/folder2/subfolder/file.js'
+	],
+	'packages/package/passContextWithReadme/*': [
+		'packages/package/passContextWithReadme/required.md',
+		'packages/package/passContextWithReadme/HISTORY.md'
+	],
+	'packages/package/passContextWithReadme/brandA/**/*': [
+		'packages/package/passContextWithReadme/brandA/README.md',
+		'packages/package/passContextWithReadme/brandA/folder1',
+		'packages/package/passContextWithReadme/brandA/folder1/file.scss',
+		'packages/package/passContextWithReadme/brandA/folder1/file.css',
+		'packages/package/passContextWithReadme/brandA/folder2',
+		'packages/package/passContextWithReadme/brandA/folder2/file.js',
+		'packages/package/passContextWithReadme/brandA/folder2/file.spec.js',
+		'packages/package/passContextWithReadme/brandA/folder2/file.json',
+		'packages/package/passContextWithReadme/brandA/folder2/subfolder',
+		'packages/package/passContextWithReadme/brandA/folder2/subfolder/file.js'
 	]
 };
 

--- a/__tests__/unit/_validate/check-package-structure.test.js
+++ b/__tests__/unit/_validate/check-package-structure.test.js
@@ -135,4 +135,11 @@ describe('Check validation', () => {
 			checkValidation(validationConfigWithChangelog, 'packages/package/passContext', ['brandA'])
 		).resolves.toEqual();
 	});
+
+	test('Resolves for context organised into brands with brand specific README.md', async () => {
+		expect.assertions(1);
+		await expect(
+			checkValidation(validationConfigWithChangelog, 'packages/package/passContextWithReadme', ['brandA'])
+		).resolves.toEqual();
+	});
 });

--- a/lib/js/_validate/_check-package-structure.js
+++ b/lib/js/_validate/_check-package-structure.js
@@ -219,8 +219,8 @@ async function checkPackageStructure(pathToPackage, globSettings, brand) {
 
 			// Check based on file type
 			if (
-				!isBrandReadme(brand, relativeFileName) &&
 				!isRequired(relativeFilePath) &&
+				!isBrandReadme(brand, relativeFileName) &&
 				!isFolder(filePath, relativeFilePath, brand) &&
 				!isFileType(relativeFilePath, brand)
 			) {

--- a/lib/js/_validate/_check-package-structure.js
+++ b/lib/js/_validate/_check-package-structure.js
@@ -28,6 +28,26 @@ let requiredFiles;
 let results;
 
 /**
+ * Check if a context brand folder is configured with a README.md
+ * Optionally allowed in addition to required README.md at context package root
+ * Returns true if match found
+ * @private
+ * @function isBrandReadme
+ * @param {String} brand optional name of the context brand
+ * @param {String} relativeFileName file name relative to the package root
+ * @return {Boolean}
+ */
+function isBrandReadme(brand, relativeFileName) {
+	const brandReadme = relativeFileName === `${brand}/README.md`;
+
+	if (brandReadme) {
+		reporter.success('validating', relativeFileName, 'optional brand README exists');
+	}
+
+	return brandReadme;
+}
+
+/**
  * Check if a file/folder matches any files excluded from validation
  * Allows partial matches on the end of the path to cater for cwd
  * Returns true if match found
@@ -199,6 +219,7 @@ async function checkPackageStructure(pathToPackage, globSettings, brand) {
 
 			// Check based on file type
 			if (
+				!isBrandReadme(brand, relativeFileName) &&
 				!isRequired(relativeFilePath) &&
 				!isFolder(filePath, relativeFilePath, brand) &&
 				!isFileType(relativeFilePath, brand)


### PR DESCRIPTION
New Feature: Allow `README.md` files to appear within brand folders in the new `brand-context` package.

Currently, the `brand-context` package requires a `README.md` file to appear in the root of the package the same as any other toolkit package, this change means that you can also _optionally_ include a `README.md` file inside each of the brand folders within the `brand-context` package.

- REQUIRED: `brand-context/README.md`
- OPTIONAL: `brand-context/brand/README.md`

This allows for brand-specific documentation instead of putting it all into the main `README.md` file.

![may4th](https://user-images.githubusercontent.com/853933/80973397-3b63a700-8e17-11ea-8077-87bfc56eccdc.gif)
