### PR TITLE
Explicitly specify version in npx call

### DIFF
--- a/__tests__/unit/_publish/create-install-message.test.js
+++ b/__tests__/unit/_publish/create-install-message.test.js
@@ -9,17 +9,24 @@ const fs = require('fs');
 jest.mock('../../../lib/js/_utils/_check-context-version');
 jest.mock('@springernature/util-cli-reporter');
 
+jest.mock('latest-version');
+const latestVersion = require('latest-version');
+latestVersion.mockImplementation(() => '1.0.0');
+
 jest.mock('path/to/old-package/package.json', () => ({
-	name: 'old-style-component'
+	name: 'old-style-component',
+	version: '1.0.0',
 }), {virtual: true});
 
 jest.mock('path/to/package/package.json', () => ({
 	name: 'new-style-component',
+	version: '1.0.0',
 	brandContext: '^1.0.0'
 }), {virtual: true});
 
 jest.mock('path/to/other-package/package.json', () => ({
 	name: 'new-style-component',
+	version: '1.0.0',
 	brandContext: '^1.0.0',
 	scripts: {test: null}
 }), {virtual: true});
@@ -58,7 +65,7 @@ describe('Context defined', () => {
 				'@springernature',
 				'valid-context'
 			)
-		).resolves.toEqual();
+		).resolves.toEqual('npx @springernature/util-context-warning@1.0.0 -p new-style-component@1.0.0 -v 1.2.0 1.5.0');
 		expect(spy).toHaveBeenCalled();
 	});
 
@@ -70,7 +77,7 @@ describe('Context defined', () => {
 				'@springernature',
 				'valid-context'
 			)
-		).resolves.toEqual();
+		).resolves.toEqual('npx @springernature/util-context-warning@1.0.0 -p new-style-component@1.0.0 -v 1.2.0 1.5.0');
 		expect(spy).toHaveBeenCalled();
 	});
 

--- a/lib/js/_publish/_create-install-message.js
+++ b/lib/js/_publish/_create-install-message.js
@@ -7,6 +7,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const latestVersion = require('latest-version');
 const reporter = require('@springernature/util-cli-reporter');
 
 const checkContextVersion = require('../_utils/_check-context-version');
@@ -31,9 +32,11 @@ async function createInstallMessage(pathToPackage, scope, packageName) {
 
 	reporter.init('none'); // Suppress CLI reporting
 
+	const installMessagePackage = '@springernature/util-context-warning';
+	const latestInstallMessageVersion = await latestVersion(installMessagePackage);
 	const matchingVersions = await checkContextVersion(scope, packageName, packageJson.brandContext);
 	const thePackage = `${packageJson.name}@${packageJson.version}`;
-	const npxCommand = `npx @springernature/util-context-warning -p ${thePackage} -v ${matchingVersions.join(' ')}`;
+	const npxCommand = `npx ${installMessagePackage}@${latestInstallMessageVersion} -p ${thePackage} -v ${matchingVersions.join(' ')}`;
 
 	if (packageJson.scripts) {
 		packageJson.scripts.postinstall = npxCommand;
@@ -47,6 +50,8 @@ async function createInstallMessage(pathToPackage, scope, packageName) {
 
 	reporter.info('update package.json', 'adding postinstall messaging for brand context');
 	fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2), 'utf-8');
+
+	return npxCommand;
 }
 
 module.exports = createInstallMessage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/frontend-package-manager",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1939,6 +1939,11 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3959,6 +3964,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
     "inquirer": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
@@ -5451,6 +5461,14 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "requires": {
+        "package-json": "^6.3.0"
+      }
+    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -5899,8 +5917,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -6369,6 +6386,17 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
+    "package-json": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "requires": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6613,6 +6641,24 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        }
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6764,6 +6810,22 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "registry-auth-token": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+      "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
+      "requires": {
+        "rc": "^1.2.8"
+      }
+    },
+    "registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "requires": {
+        "rc": "^1.2.8"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gitignore-globs": "^0.1.1",
     "globby": "^10.0.1",
     "inquirer": "^7.0.0",
+    "latest-version": "^5.1.0",
     "listr": "^0.14.3",
     "minimatch": "^3.0.4",
     "npm-registry-client": "^8.6.0",


### PR DESCRIPTION
`npx` command was failing when run via artifactory. The suspicion is because a version was not being specified and `@latest` was being used by default. This PR explicitly states the latest version by:

1. grabbing the latest version from NPM
2. appending it to the `npx` call in the format `package@version`