### PR TITLE
Fix Publish Bug

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 5.1.2 (2020-06-02)
+    * BUG: missing argument from publish function
+
 ## 5.1.1 (2020-05-14)
     * BUG: npx command causing issues when version not explicitly stated
 

--- a/lib/js/_publish.js
+++ b/lib/js/_publish.js
@@ -83,7 +83,7 @@ module.exports = (allConfigs, currentWorkingDirectory) => {
 				// Iterate over paths and optionally publish
 				for (const current of packagePaths) {
 					const pathToPackage = path.resolve(currentWorkingDirectory, current);
-					await publishPackage(pathToPackage, contextConfig.scope, contextConfig.brandContextName);
+					await publishPackage(pathToPackage, contextConfig.scope, contextConfig.brandContextName, currentWorkingDirectory);
 				}
 			}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@springernature/frontend-package-manager",
   "description": "handles the creation, validation, and publication of packages",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "license": "LGPL-3.0",
   "keywords": [
     "node",


### PR DESCRIPTION
The `currentWorkingDirectory` argument was missing from the publish function. This meant that an error was thrown _after_ publishing a package as that argument is used to return to the packages folder.

This didn't cause an issue until we had a PR that wanted to publish more than 1 package. In this instance, it would publish the first, then error when trying to look for the second package.