### PR TITLE
Bug Fix: Race condition on folder creation

### DIFF
--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -101,15 +101,21 @@ const __fsMockFilesEmpty = () => {
 
 const __fsMkdir = (path, callback) => {
 	if (path.includes('package-error') || path.includes('package-css-folders/scss/A')) {
-		callback('mkdir error');
+		callback(new Error('mkdir error'));
 	} else {
 		callback();
 	}
 };
 
+const __fsMkdirSync = path => {
+	if (path.includes('package-error') || path.includes('package-css-folders/scss/A')) {
+		throw new Error('mkdirSync error');
+	}
+};
+
 const __fsWriteFile = (path, _contents, callback) => {
 	if (path.includes('package-error') || path.includes('package-file-error')) {
-		callback('writefile error');
+		callback(new Error('writefile error'));
 	} else {
 		callback();
 	}
@@ -118,6 +124,7 @@ const __fsWriteFile = (path, _contents, callback) => {
 fs.__fsMockFiles = __fsMockFiles;
 fs.__fsMockFilesEmpty = __fsMockFilesEmpty;
 fs.mkdir = __fsMkdir;
+fs.mkdirSync = __fsMkdirSync;
 fs.writeFile = __fsWriteFile;
 
 module.exports = fs;

--- a/__tests__/unit/_create/build-new-package.test.js
+++ b/__tests__/unit/_create/build-new-package.test.js
@@ -165,7 +165,7 @@ describe('Create task objects', () => {
 		result[0].task();
 
 		expect.assertions(1);
-		expect(consoleOutput).toEqual('mkdir error');
+		expect(consoleOutput).toEqual(new Error('mkdirSync error'));
 	});
 
 	test('Log error if unable to create package.json', () => {
@@ -189,7 +189,7 @@ describe('Create task objects', () => {
 		result[2].task();
 
 		expect.assertions(1);
-		expect(consoleOutput).toEqual('writefile error');
+		expect(consoleOutput).toEqual(new Error('writefile error'));
 	});
 
 	test('Log error if unable to create file', () => {
@@ -213,7 +213,7 @@ describe('Create task objects', () => {
 		result[2].task();
 
 		expect.assertions(1);
-		expect(consoleOutput).toEqual('writefile error');
+		expect(consoleOutput).toEqual(new Error('writefile error'));
 	});
 
 	test('Log error if unable to create folder', () => {
@@ -237,31 +237,7 @@ describe('Create task objects', () => {
 		result[1].task();
 
 		expect.assertions(1);
-		expect(consoleOutput).toEqual('mkdir error');
-	});
-
-	test('Log error if unable to create .gitkeep file in folder', () => {
-		const result = buildNewPackage(
-			{
-				scope: 'scope',
-				required: ['file.ext'],
-				packagesDirectory: 'path/to'
-			},
-			'.',
-			'license',
-			{
-				pkgname: 'package-file-error',
-				description: 'this is a description',
-				author: 'Joe Bloggs',
-				folders: ['view']
-			}
-		);
-
-		// Run the first task
-		result[1].task();
-
-		expect.assertions(1);
-		expect(consoleOutput).toEqual('writefile error');
+		expect(consoleOutput).toEqual(new Error('mkdir error'));
 	});
 
 	test('Log error if unable to create CSSDirectoryStructure', () => {
@@ -288,6 +264,6 @@ describe('Create task objects', () => {
 		result[2].task();
 
 		expect.assertions(1);
-		expect(consoleOutput).toEqual('mkdir error');
+		expect(consoleOutput).toEqual(new Error('mkdir error'));
 	});
 });

--- a/lib/js/_create.js
+++ b/lib/js/_create.js
@@ -76,7 +76,8 @@ module.exports = (defaultConfig, currentWorkingDirectory, allToolkitsInfo) => {
 			// Generate task list for building the new package
 			const pathToPackage = path.resolve(currentWorkingDirectory, toolkitDetails.path);
 			const tasks = new Listr(
-				buildNewPackage(toolkitDetails.config, pathToPackage, globalLicense, allAnswers)
+				buildNewPackage(toolkitDetails.config, pathToPackage, globalLicense, allAnswers),
+				{concurrent: true}
 			);
 
 			// Run the build package tasks

--- a/lib/js/_create.js
+++ b/lib/js/_create.js
@@ -49,12 +49,6 @@ module.exports = (defaultConfig, currentWorkingDirectory, allToolkitsInfo) => {
 	const globalLicense = getLicense(packageJson);
 	const toolkitNames = Object.keys(allToolkitsInfo);
 
-	try {
-		throw new Error('mkdirSync error');
-	} catch (err) {
-		console.error(err.message);
-	}
-
 	(async () => {
 		try {
 			// Choose a toolkit to create package for

--- a/lib/js/_create.js
+++ b/lib/js/_create.js
@@ -49,6 +49,12 @@ module.exports = (defaultConfig, currentWorkingDirectory, allToolkitsInfo) => {
 	const globalLicense = getLicense(packageJson);
 	const toolkitNames = Object.keys(allToolkitsInfo);
 
+	try {
+		throw new Error('mkdirSync error');
+	} catch (err) {
+		console.error(err.message);
+	}
+
 	(async () => {
 		try {
 			// Choose a toolkit to create package for

--- a/lib/js/_create/_build-new-package.js
+++ b/lib/js/_create/_build-new-package.js
@@ -62,24 +62,32 @@ function generateFolders(cssFolders, answers) {
 
 	if (answers.folders) {
 		for (const folder of answers.folders) {
-			folderTasks.push({
-				title: `Create folder ${answers.pkgname}/${folder}`,
-				task: () => fs.mkdir(`${filePath}/${answers.pkgname}/${folder}`, error => {
-					if (error) {
-						console.error(error);
-					} else {
-						fs.writeFile(`${filePath}/${answers.pkgname}/${folder}/.gitkeep`, '// temporary file, delete as appropriate', error => {
-							if (error) {
-								console.error(error);
-							}
-						});
-					}
-				})
-			});
+			// If the folder has sub-folders create those as well
 			if (cssFolders && cssFolders[folder]) {
 				folderTasks.push({
+					title: `Create folder ${answers.pkgname}/${folder}`,
+					task: () => {
+						// Create the parent folder
+						// Make sure it exists before processing next task
+						try {
+							fs.mkdirSync(`${filePath}/${answers.pkgname}/${folder}`);
+						} catch (error) {
+							console.error(error)
+						}
+					}
+				},
+				{
 					title: `Create sub-folder structure within ${answers.pkgname}/${folder}`,
 					task: () => createCSSDirectoryStructure(cssFolders[folder], answers, folder)
+				});
+			} else {
+				folderTasks.push({
+					title: `Create folder ${answers.pkgname}/${folder}`,
+					task: () => fs.mkdir(`${filePath}/${answers.pkgname}/${folder}`, error => {
+						if (error) {
+							console.error(error);
+						}
+					})
 				});
 			}
 		}
@@ -143,13 +151,20 @@ module.exports = (config, basePath, globalLicense, answers) => {
 	return [
 		{
 			title: `Create folder ${answers.pkgname}`,
-			task: () => fs.mkdir(`${filePath}/${answers.pkgname}`, error => {
-				if (error) {
-					console.error(error);
+			task: () => {
+				// Create the package folder
+				// Make sure it exists before processing next task
+				try {
+					fs.mkdirSync(`${filePath}/${answers.pkgname}`);
+				} catch (error) {
+					console.error(error)
 				}
-			})
+			}
 		},
 		...generateFolders(config.CSSDirectoryStructure, answers),
-		...generateFiles(config.required, answers)
+		...generateFiles(
+			[...config.required, config.changelog],
+			answers
+		)
 	];
 };

--- a/lib/js/_create/_build-new-package.js
+++ b/lib/js/_create/_build-new-package.js
@@ -72,7 +72,7 @@ function generateFolders(cssFolders, answers) {
 						try {
 							fs.mkdirSync(`${filePath}/${answers.pkgname}/${folder}`);
 						} catch (error) {
-							console.error(error)
+							console.error(error);
 						}
 					}
 				},
@@ -157,7 +157,7 @@ module.exports = (config, basePath, globalLicense, answers) => {
 				try {
 					fs.mkdirSync(`${filePath}/${answers.pkgname}`);
 				} catch (error) {
-					console.error(error)
+					console.error(error);
 				}
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/frontend-package-manager",
-  "version": "5.1.0",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Uncovered a bug today with the `create` script.

If you need to create sub-folders, that task sometimes kicks in before the creation of the parent folder has finished.

This PR makes the creation of the parent folder synchronous so that the next task will not start until it is complete.