### PR TITLE
Force npx to use default registry

### DIFF
--- a/__tests__/unit/_publish/create-install-message.test.js
+++ b/__tests__/unit/_publish/create-install-message.test.js
@@ -65,7 +65,7 @@ describe('Context defined', () => {
 				'@springernature',
 				'valid-context'
 			)
-		).resolves.toEqual('npx @springernature/util-context-warning@1.0.0 -p new-style-component@1.0.0 -v 1.2.0 1.5.0');
+		).resolves.toEqual('npm_config_registry=https://registry.npmjs.org/ npx @springernature/util-context-warning@1.0.0 -p new-style-component@1.0.0 -v 1.2.0 1.5.0');
 		expect(spy).toHaveBeenCalled();
 	});
 
@@ -77,7 +77,7 @@ describe('Context defined', () => {
 				'@springernature',
 				'valid-context'
 			)
-		).resolves.toEqual('npx @springernature/util-context-warning@1.0.0 -p new-style-component@1.0.0 -v 1.2.0 1.5.0');
+		).resolves.toEqual('npm_config_registry=https://registry.npmjs.org/ npx @springernature/util-context-warning@1.0.0 -p new-style-component@1.0.0 -v 1.2.0 1.5.0');
 		expect(spy).toHaveBeenCalled();
 	});
 

--- a/lib/js/_publish/_create-install-message.js
+++ b/lib/js/_publish/_create-install-message.js
@@ -33,10 +33,11 @@ async function createInstallMessage(pathToPackage, scope, packageName) {
 	reporter.init('none'); // Suppress CLI reporting
 
 	const installMessagePackage = '@springernature/util-context-warning';
+	const npxRepository = 'https://registry.npmjs.org/'; // to avoid clashes with private package registry
 	const latestInstallMessageVersion = await latestVersion(installMessagePackage);
 	const matchingVersions = await checkContextVersion(scope, packageName, packageJson.brandContext);
 	const thePackage = `${packageJson.name}@${packageJson.version}`;
-	const npxCommand = `npx ${installMessagePackage}@${latestInstallMessageVersion} -p ${thePackage} -v ${matchingVersions.join(' ')}`;
+	const npxCommand = `npm_config_registry=${npxRepository} npx ${installMessagePackage}@${latestInstallMessageVersion} -p ${thePackage} -v ${matchingVersions.join(' ')}`;
 
 	if (packageJson.scripts) {
 		packageJson.scripts.postinstall = npxCommand;


### PR DESCRIPTION
When using a private registry for your app, the NPX command can fail [because of this bug](https://github.com/zkat/npx/issues/200). This PR forces the NPX command to use the default registry to hopefully avoid this.