### PR TITLE
Minify demo

### DIFF
--- a/__tests__/unit/_utils/generate-demo.test.js
+++ b/__tests__/unit/_utils/generate-demo.test.js
@@ -30,6 +30,7 @@ describe('checkDemoFolder', () => {
 		expect(renderer).toHaveBeenCalledWith({
 			'brandContext': '@npmscope/context',
 			'demoCodeFolder': 'demo',
+			'minify': false,
 			'packageRoot': 'path/to/valid-toolkit-package',
 			'reportingLevel': 'info'
 		});
@@ -80,6 +81,7 @@ describe('createDemoFile', () => {
 		expect(renderer).toHaveBeenCalledWith({
 			'brandContext': '@npmscope/context',
 			'demoCodeFolder': 'demo',
+			'minify': false,
 			'distFolderPath': path.join(process.cwd(), 'path/to/valid-toolkit-package/demo/dist'),
 			'packageRoot': 'path/to/valid-toolkit-package',
 			'reportingLevel': 'info'

--- a/bin/demo.js
+++ b/bin/demo.js
@@ -19,6 +19,10 @@ const argv = require('yargs')
 	.nargs('s', 1)
 	.describe('s', 'NPM scope for context package')
 	.default('s', 'springernature')
+	.alias('m', 'minify')
+	.boolean('m')
+	.describe('m', 'Minify JS and CSS')
+	.default('m', false)
 	.help('h')
 	.alias('h', 'help')
 	.argv;
@@ -35,7 +39,7 @@ const exitWithError = require('../lib/js/_utils/_error');
 
 		const brand = argv.package.split(/-(.+)?$/)[0];
 		const path = `toolkits/${brand}/packages/${argv.package}`;
-		createDemoFile(path, argv.context, argv.scope, 'title');
+		createDemoFile(path, argv.context, argv.scope, argv.minify, 'title');
 	} catch (error) {
 		exitWithError(error);
 	}

--- a/lib/js/_publish.js
+++ b/lib/js/_publish.js
@@ -28,7 +28,7 @@ const createDemoFile = require('./_utils/_generate-demo').createDemoFile;
  */
 async function publishPackage(pathToPackage, scope, brandContextName, currentWorkingDirectory) {
 	if (await checkCurrentVersion(pathToPackage, true)) {
-		await createDemoFile(pathToPackage, brandContextName, scope);
+		await createDemoFile(pathToPackage, brandContextName, scope, true);
 		await createInstallMessage(pathToPackage, scope, brandContextName);
 		await publishToNpm(pathToPackage, currentWorkingDirectory);
 	}

--- a/lib/js/_utils/_generate-demo.js
+++ b/lib/js/_utils/_generate-demo.js
@@ -63,12 +63,12 @@ async function demoCreation(pathToPackage, npmContext, reporting, minify, distFo
  * @param {String} pathToPackage package path on filesystem
  * @param {String} brandContextName name of brand context on github
  * @param {String} scope package scope on NPM
- * @param {Boolean} minify minify the js and css output
+ * @param {Boolean} [minify=false] minify the js and css output
  * @param {String} [reporting=info] CLI reporting level
  * @return {Promise}
  */
 // eslint-disable-next-line max-params
-async function checkDemoFolder(pathToPackage, brandContextName, scope, minify, reporting = 'info') {
+async function checkDemoFolder(pathToPackage, brandContextName, scope, minify = false, reporting = 'info') {
 	const npmContext = `@${scope}/${brandContextName}`;
 	await demoCreation(pathToPackage, npmContext, reporting, minify);
 }
@@ -80,7 +80,7 @@ async function checkDemoFolder(pathToPackage, brandContextName, scope, minify, r
  * @param {String} pathToPackage package path on filesystem
  * @param {String} brandContextName name of brand context on github
  * @param {String} scope package scope on NPM
- * @param {Boolean} minify minify the js and css output
+ * @param {Boolean} [minify=false] minify the js and css output
  * @param {String} [reporting=info] CLI reporting level
  * @return {Promise}
  */

--- a/lib/js/_utils/_generate-demo.js
+++ b/lib/js/_utils/_generate-demo.js
@@ -20,14 +20,17 @@ const demoFolder = 'demo';
  * @param {String} pathToPackage package path on filesystem
  * @param {String} npmContext name of brand context on NPM
  * @param {String} [reporting=info] CLI reporting level
+ * @param {Boolean} minify minify the js and css output
  * @param {String} [distFolder] optionally write index.html to this location
  * @return {Promise}
  */
-async function demoCreation(pathToPackage, npmContext, reporting, distFolder) {
+// eslint-disable-next-line max-params
+async function demoCreation(pathToPackage, npmContext, reporting, minify, distFolder) {
 	const renderConfig = {
 		demoCodeFolder: demoFolder,
 		reportingLevel: reporting,
 		packageRoot: pathToPackage,
+		minify: minify,
 		brandContext: npmContext,
 		...(distFolder && {distFolderPath: distFolder})
 	};
@@ -60,12 +63,14 @@ async function demoCreation(pathToPackage, npmContext, reporting, distFolder) {
  * @param {String} pathToPackage package path on filesystem
  * @param {String} brandContextName name of brand context on github
  * @param {String} scope package scope on NPM
+ * @param {Boolean} minify minify the js and css output
  * @param {String} [reporting=info] CLI reporting level
  * @return {Promise}
  */
-async function checkDemoFolder(pathToPackage, brandContextName, scope, reporting = 'info') {
+// eslint-disable-next-line max-params
+async function checkDemoFolder(pathToPackage, brandContextName, scope, minify, reporting = 'info') {
 	const npmContext = `@${scope}/${brandContextName}`;
-	await demoCreation(pathToPackage, npmContext, reporting);
+	await demoCreation(pathToPackage, npmContext, reporting, minify);
 }
 
 /**
@@ -75,13 +80,15 @@ async function checkDemoFolder(pathToPackage, brandContextName, scope, reporting
  * @param {String} pathToPackage package path on filesystem
  * @param {String} brandContextName name of brand context on github
  * @param {String} scope package scope on NPM
+ * @param {Boolean} minify minify the js and css output
  * @param {String} [reporting=info] CLI reporting level
  * @return {Promise}
  */
-async function createDemoFile(pathToPackage, brandContextName, scope, reporting = 'info') {
+// eslint-disable-next-line max-params
+async function createDemoFile(pathToPackage, brandContextName, scope, minify = false, reporting = 'info') {
 	const npmContext = `@${scope}/${brandContextName}`;
 	const distFolder = path.resolve(pathToPackage, demoFolder, 'dist');
-	await demoCreation(pathToPackage, npmContext, reporting, distFolder);
+	await demoCreation(pathToPackage, npmContext, reporting, minify, distFolder);
 }
 
 module.exports = {


### PR DESCRIPTION
Add new asset minification options from the `util-package-renderer`

- add minify option to `lib/js/_utils/_generate-demo.js`, defaults to `false`
- minify the js and css at the publish step (NPM published `demo/dist/index.html` contains minified code)
- endpoint at `bin/demo.js` allows setting of minify flag

## Note

The suppression of the `max-params` rule indicates an issue with function complexity. This is due to the package-manager growing over time, and will be addressed across the package in a separate commit.