### PR TITLE
Blocking new packages

### DIFF
--- a/__tests__/unit/_utils/check-current-version.test.js
+++ b/__tests__/unit/_utils/check-current-version.test.js
@@ -4,6 +4,9 @@
  */
 'use strict';
 
+const errorModule = require('../../../lib/js/_utils/_error');
+jest.mock('../../../lib/js/_utils/_error', () => jest.fn())
+
 jest.mock('@springernature/util-cli-reporter');
 jest.mock('../../../lib/js/_utils/_error');
 jest.mock('../../../lib/js/_utils/_get-latest-version');
@@ -35,46 +38,74 @@ jest.mock('path/to/global-error/package.json', () => ({
 
 const checkCurrentVersion = require('../../../lib/js/_utils/_check-current-version');
 
-describe('Compare NPM version and package.json version', () => {
-	test('Resolve with `true` when newer version in package.json - 3.0.0 > 2.0.0', async () => {
-		expect.assertions(1);
-		await expect(
-			checkCurrentVersion('path/to/global-package')
-		).resolves.toEqual(true);
+describe('Validation step', () => {
+	describe('Check for new packages when publication ALLOWED', () => {
+		test('Exit early when new packages allowed at validation step', async () => {
+			expect.assertions(1);
+			await expect(
+				checkCurrentVersion('path/to/global-package', false, false)
+			).resolves.toEqual();
+		});
 	});
 
-	test('Resolve with `true` when NPM returns false and package.json version present', async () => {
-		expect.assertions(1);
-		await expect(
-			checkCurrentVersion('path/to/global-unpublished')
-		).resolves.toEqual(true);
-	});
+	describe('Check for new packages when publication BLOCKED', () => {
+		test('Resolve with `false` when version is 0.0.0 in package.json (no publish)', async () => {
+			expect.assertions(1);
+			await expect(
+				checkCurrentVersion('path/to/global-none', false, true)
+			).resolves.toEqual();
+		});
 
-	test('Resolve with `false` when same version in package.json - 2.0.0 == 2.0.0', async () => {
-		expect.assertions(1);
-		await expect(
-			checkCurrentVersion('path/to/global-match')
-		).resolves.toEqual();
+		test('Throw when NPM returns false and package.json version present', async () => {
+			await checkCurrentVersion('path/to/global-unpublished', false, true);
+			expect(errorModule.mock.calls.length).toBe(1);
+			expect(errorModule).toBeCalledWith(new Error('publishing blocked via `config.blockNewPackages`'));
+		});
 	});
+});
 
-	test('Resolve with `false` when older version in package.json - 1.0.0 > 2.0.0', async () => {
-		expect.assertions(1);
-		await expect(
-			checkCurrentVersion('path/to/global-older')
-		).resolves.toEqual();
-	});
+describe('Publication step', () => {
+	describe('Compare NPM version and package.json version', () => {
+		test('Resolve with `true` when newer version in package.json - 3.0.0 > 2.0.0', async () => {
+			expect.assertions(1);
+			await expect(
+				checkCurrentVersion('path/to/global-package')
+			).resolves.toEqual(true);
+		});
 
-	test('Resolve with `false` when version is 0.0.0 in package.json (no publish)', async () => {
-		expect.assertions(1);
-		await expect(
-			checkCurrentVersion('path/to/global-none')
-		).resolves.toEqual();
-	});
+		test('Resolve with `true` when NPM returns false and package.json version present', async () => {
+			expect.assertions(1);
+			await expect(
+				checkCurrentVersion('path/to/global-unpublished')
+			).resolves.toEqual(true);
+		});
 
-	test('Rejects with an error if issue contacting NPM', async () => {
-		expect.assertions(1);
-		await expect(
-			checkCurrentVersion('path/to/global-error')
-		).rejects.toBeInstanceOf(Error);
+		test('Resolve with `false` when same version in package.json - 2.0.0 == 2.0.0', async () => {
+			expect.assertions(1);
+			await expect(
+				checkCurrentVersion('path/to/global-match')
+			).resolves.toEqual();
+		});
+
+		test('Resolve with `false` when older version in package.json - 1.0.0 > 2.0.0', async () => {
+			expect.assertions(1);
+			await expect(
+				checkCurrentVersion('path/to/global-older')
+			).resolves.toEqual();
+		});
+
+		test('Resolve with `false` when version is 0.0.0 in package.json (no publish)', async () => {
+			expect.assertions(1);
+			await expect(
+				checkCurrentVersion('path/to/global-none')
+			).resolves.toEqual();
+		});
+
+		test('Rejects with an error if issue contacting NPM', async () => {
+			expect.assertions(1);
+			await expect(
+				checkCurrentVersion('path/to/global-error')
+			).rejects.toBeInstanceOf(Error);
+		});
 	});
 });

--- a/config/context.json
+++ b/config/context.json
@@ -5,6 +5,7 @@
   "brandContextName": "brand-context",
   "brands": [],
   "changelog": "HISTORY.md",
+  "blockNewPackages": false,
   "required": [
     "README.md",
     "package.json"

--- a/config/default.json
+++ b/config/default.json
@@ -3,6 +3,7 @@
   "toolkitsDirectory": "toolkits",
   "packagesDirectory": "packages",
 	"changelog": "HISTORY.md",
+  "blockNewPackages": false,
 	"required": [
 		"README.md",
 		"package.json"

--- a/lib/js/_utils/_check-current-version.js
+++ b/lib/js/_utils/_check-current-version.js
@@ -10,39 +10,69 @@ const reporter = require('@springernature/util-cli-reporter');
 
 const checkNewVersion = require('./_check-new-version');
 const getLatestVersion = require('./_get-latest-version');
+const error = require('./_error');
 
 /**
  * Do we publish a new version
  * Compare package.json version and NPM version
+ * Check if publishing a completely new package
  * @async
  * @function checkCurrentVersion
  * @param {String} pathToPackage package path on filesystem
  * @param {Boolean} printTitle log the title to the CLI
+ * @param {Boolean} blockNewPackages block publication of new packages (validation step only)
  * @return {Promise<Boolean>}
  */
-async function checkCurrentVersion(pathToPackage, printTitle) {
-	const package_ = require(path.join(pathToPackage, 'package.json'));
-	const newVersion = checkNewVersion(package_);
+async function checkCurrentVersion(pathToPackage, printTitle, blockNewPackages) {
+	const publicationStep = typeof blockNewPackages === 'undefined';
 
-	if (printTitle) {
-		reporter.title(package_.name);
-	}
-	reporter.info('checking package', package_.name);
-
-	if (newVersion === '0.0.0') {
-		reporter.info('unpublished', 'version is 0.0.0');
+	// New packages allowed
+	if (!publicationStep && !blockNewPackages) {
 		return;
 	}
 
+	// Check for a new package version in repo
+	// Get the latest version from NPM
+	const package_ = require(path.join(pathToPackage, 'package.json'));
+	const newVersion = checkNewVersion(package_);
 	const latest = await getLatestVersion(package_.name.replace(/\//g, '%2F'));
-	const publishNewVersion = (latest) ? semver.gt(newVersion, latest) : true;
 
-	reporter.info('version found on NPM', latest || 'none');
-	reporter.info('package.json version', newVersion);
-	reporter.info('update package', publishNewVersion.toString(), (publishNewVersion) ? `${newVersion} > ${latest || 'none'}` : '');
+	// Publication step logging
+	if (publicationStep) {
+		if (printTitle) {
+			reporter.title(package_.name);
+		}
+		reporter.info('checking package', package_.name);
+	}
 
-	if (publishNewVersion) {
-		return true;
+	// Don't publish at v0.0.0
+	// Allow unpublished packages to exist in the repo even when `blockNewPackages`
+	if (newVersion === '0.0.0') {
+		if (publicationStep) {
+			reporter.info('unpublished', 'version is 0.0.0');
+		}
+		return;
+	}
+
+	// Validation step
+	// Check for new packages
+	if (!publicationStep && blockNewPackages && typeof latest === 'undefined') {
+		reporter.info('blockNewPackages', blockNewPackages, `publishing new packages is blocked`);
+		reporter.fail('new package detected', 'true');
+		error(new Error('publishing blocked via `config.blockNewPackages`'));
+	}
+
+	// Publish to NPM only at publication step
+	if (publicationStep) {
+		const publishNewVersion = (latest) ? semver.gt(newVersion, latest) : true;
+
+		reporter.info('version found on NPM', latest || 'none');
+		reporter.info('package.json version', newVersion);
+		reporter.info('update package', publishNewVersion.toString(), (publishNewVersion) ? `${latest || 'none'} -> ${newVersion}` : '');
+
+		if (publishNewVersion) {
+			return true;
+		}
 	}
 }
 

--- a/lib/js/_utils/_check-new-version.js
+++ b/lib/js/_utils/_check-new-version.js
@@ -11,7 +11,6 @@ const error = require('./_error');
 /**
  * Check for valid version in package.json
  * Return if valid
- * @async
  * @function checkNewVersion
  * @param {Object} package_ package.json data object
  * @return {String}

--- a/lib/js/_validate.js
+++ b/lib/js/_validate.js
@@ -24,6 +24,7 @@ const checkContextDependency = require('./_validate/_check-package-context');
 const checkContextStructure = require('./_validate/_check-context-structure');
 const checkContextBrands = require('./_validate/_check-context-brands');
 const checkDemoFolder = require('./_utils/_generate-demo').checkDemoFolder;
+const checkCurrentVersion = require('./_utils/_check-current-version');
 
 let packageJson;
 let globalLicense;
@@ -56,6 +57,7 @@ function filterPackagePathList(filterByPackage, allPackagePaths) {
  */
 async function validatePackage(config, brands, brandContextName, pathToPackage) {
 	await checkNaming(config, pathToPackage);
+	await checkCurrentVersion(pathToPackage, false, config.blockNewPackages);
 	await checkLicense(pathToPackage, globalLicense);
 	await checkPackageStructure(config, pathToPackage);
 	await checkContextDependency(config, pathToPackage, brands, brandContextName);


### PR DESCRIPTION
Allow the toolkit repository to be configured to block new package publication.
This is configured via the `package-manager.json` file in the toolkit repository using the key `blockNewPackages`

- If `blockNewPackages` is false, nothing changes
- If `blockNewPackages` is true
    - ALLOW updates to existing packages
    - ALLOW commit new packages versioned as `0.0.0` (not published to NPM)
    - BLOCK publishing new packages to NPM